### PR TITLE
Prevent keyboard events from running inputmask if the input is disabled or readonly.

### DIFF
--- a/js/jquery.inputmask.date.extentions.js
+++ b/js/jquery.inputmask.date.extentions.js
@@ -338,6 +338,40 @@ Optional extentions on the jquery.inputmask base
                                             }
                                         }
                                     }
+
+                                    /*if ( isValid && opts.regex.hrs24.test(chrs) ) {
+
+                                        var tmp = parseInt(chrs,10);
+
+                                        if ( tmp == 24 ) {
+                                            buffer[pos+5] = "a";
+                                            buffer[pos+6] = "m";
+                                        } else {
+                                            buffer[pos+5] = "p";
+                                            buffer[pos+6] = "m";
+                                        }
+
+                                        console.log("time1:"+tmp+":"+buffer);
+
+                                        tmp = tmp - 12;
+
+                                        console.log("time2:"+tmp+":"+buffer);
+
+                                        if ( tmp < 10 ) {
+                                            buffer[pos] = tmp.toString();
+                                            buffer[pos-1] = "0";
+                                        } else {
+                                            buffer[pos] = tmp.toString().charAt(1);
+                                            buffer[pos-1] = tmp.toString().charAt(0);
+                                        }
+
+                                        console.log("time3:"+tmp.toString()+":"+buffer);
+
+                                        return pos;
+                                        
+                                        //
+                                    }*/
+
                                     return isValid;
                                 },
                                 cardinality: 2,

--- a/js/jquery.inputmask.date.extentions.js
+++ b/js/jquery.inputmask.date.extentions.js
@@ -20,11 +20,6 @@ Optional extentions on the jquery.inputmask base
             cardinality: 2,
             prevalidator: [{ validator: "[0-5]", cardinality: 1}]
         },
-        't': {
-            validator: "[apAP][mM]",
-            cardinality: 2,
-            prevalidator: [{validator: "[apAP]", cardinality: 1}]
-        },
         'd': { //basic day
             validator: "0[1-9]|[12][0-9]|3[01]",
             cardinality: 2,
@@ -317,7 +312,7 @@ Optional extentions on the jquery.inputmask base
                             hrs24: new RegExp("2[0-9]|1[3-9]"),
                             hrs: new RegExp("[01][0-9]|2[0-3]"), //hours
                             ampmpre: new RegExp("[apAP]"),
-                            ampm: new RegExp("[apAP][mM]")
+                            ampm: new RegExp("^[a|p|A|P][m|M]")
                         },
                         separator: ':',
                         transform : function(buffer, position, element, opts){
@@ -384,7 +379,7 @@ Optional extentions on the jquery.inputmask base
                                 validator: function(chrs, buffer, pos, strict, opts) {
                                     var isValid = opts.regex.ampm.test(chrs);
                                     if (!strict && !isValid) {
-                                        isValid = opts.regex.ampm.test(chrs.charAt(0)+'m');
+                                        isValid = opts.regex.ampm.test(chrs+'m');
                                         if (isValid) {
                                             buffer[pos - 1] = chrs.charAt(0);
                                             buffer[pos] = "m";

--- a/js/jquery.inputmask.date.extentions.js
+++ b/js/jquery.inputmask.date.extentions.js
@@ -20,6 +20,11 @@ Optional extentions on the jquery.inputmask base
             cardinality: 2,
             prevalidator: [{ validator: "[0-5]", cardinality: 1}]
         },
+        't': {
+            validator: "[apAP][mM]",
+            cardinality: 2,
+            prevalidator: [{validator: "[apAP]", cardinality: 1}]
+        },
         'd': { //basic day
             validator: "0[1-9]|[12][0-9]|3[01]",
             cardinality: 2,
@@ -47,8 +52,8 @@ Optional extentions on the jquery.inputmask base
             regex: {
                 val1pre: new RegExp("[0-3]"), //daypre
                 val1: new RegExp("0[1-9]|[12][0-9]|3[01]"), //day
-                val2pre: function(separator) { return new RegExp("((0[1-9]|[12][0-9]|3[01])\\" + separator + "[01])") }, //monthpre
-                val2: function(separator) { return new RegExp("((0[1-9]|[12][0-9])\\" + separator + "(0[1-9]|1[012]))|(30\\" + separator + "(0[13-9]|1[012]))|(31\\" + separator + "(0[13578]|1[02]))") }, //month
+                val2pre: function(separator) { return new RegExp("((0[1-9]|[12][0-9]|3[01])\\" + separator + "[01])"); }, //monthpre
+                val2: function(separator) { return new RegExp("((0[1-9]|[12][0-9])\\" + separator + "(0[1-9]|1[012]))|(30\\" + separator + "(0[13-9]|1[012]))|(31\\" + separator + "(0[13578]|1[02]))"); },//month
                 yearpre1: new RegExp("[12]"),
                 yearpre3: new RegExp("(19|20)\\d"),
                 year: new RegExp("(19|20)\\d{2}")
@@ -132,10 +137,10 @@ Optional extentions on the jquery.inputmask base
                                     if (dayMonthValue != opts.leapday)
                                         return true;
                                     else {
-                                        var year = parseInt(chrs);  //detect leap year
-                                        if (year % 4 == 0)
-                                            if (year % 100 == 0)
-                                            if (year % 400 == 0)
+                                        var year = parseInt(chrs,10);//detect leap year
+                                        if (year % 4 === 0)
+                                            if (year % 100 === 0)
+                                            if (year % 400 === 0)
                                             return true;
                                         else return false;
                                         else return true;
@@ -158,8 +163,8 @@ Optional extentions on the jquery.inputmask base
                                 }
                             }
                             return isValid;
-                        }
-                            , cardinality: 1
+                        },
+                            cardinality: 1
                         },
                         { validator: "(19|20)", cardinality: 2 },
                         { validator: "(19|20)\\d", cardinality: 3 }
@@ -173,8 +178,8 @@ Optional extentions on the jquery.inputmask base
                     placeholder: "mm/dd/yyyy",
                     alias: "dd/mm/yyyy", //reuse functionality of dd/mm/yyyy alias
                     regex: {
-                        val2pre: function(separator) { return new RegExp("((0[13-9]|1[012])\\" + separator + "[0-3])|(02\\" + separator + "[0-2])") }, //daypre
-                        val2: function(separator) { return new RegExp("((0[1-9]|1[012])\\" + separator + "(0[1-9]|[12][0-9]))|((0[13-9]|1[012])\\" + separator + "30)|((0[13578]|1[02])\\" + separator + "31)") }, //day
+                        val2pre: function(separator) { return new RegExp("((0[13-9]|1[012])\\" + separator + "[0-3])|(02\\" + separator + "[0-2])"); }, //daypre
+                        val2: function(separator) { return new RegExp("((0[1-9]|1[012])\\" + separator + "(0[1-9]|[12][0-9]))|((0[13-9]|1[012])\\" + separator + "30)|((0[13578]|1[02])\\" + separator + "31)"); }, //day
                         val1pre: new RegExp("[01]"), //monthpre
                         val1: new RegExp("0[1-9]|1[012]") //month
                     },
@@ -222,10 +227,10 @@ Optional extentions on the jquery.inputmask base
                                     if (dayMonthValue != opts.leapday)
                                         return true;
                                     else {
-                                        var year = parseInt(buffer.join('').substr(0, 4));  //detect leap year
-                                        if (year % 4 == 0)
-                                            if (year % 100 == 0)
-                                            if (year % 400 == 0)
+                                        var year = parseInt(buffer.join('').substr(0, 4),10);  //detect leap year
+                                        if (year % 4 === 0)
+                                            if (year % 100 === 0)
+                                            if (year % 400 === 0)
                                             return true;
                                         else return false;
                                         else return true;
@@ -256,42 +261,42 @@ Optional extentions on the jquery.inputmask base
                         mask: "1.2.y",
                         placeholder: "dd.mm.yyyy",
                         leapday: "29.02.",
-                        separator: '\.',
+                        separator: '.',
                         alias: "dd/mm/yyyy"
                     },
                     'dd-mm-yyyy': {
                         mask: "1-2-y",
                         placeholder: "dd-mm-yyyy",
                         leapday: "29-02-",
-                        separator: '\-',
+                        separator: '-',
                         alias: "dd/mm/yyyy"
                     },
                     'mm.dd.yyyy': {
                         mask: "1.2.y",
                         placeholder: "mm.dd.yyyy",
                         leapday: "02.29.",
-                        separator: '\.',
+                        separator: '.',
                         alias: "mm/dd/yyyy"
                     },
                     'mm-dd-yyyy': {
                         mask: "1-2-y",
                         placeholder: "mm-dd-yyyy",
                         leapday: "02-29-",
-                        separator: '\-',
+                        separator: '-',
                         alias: "mm/dd/yyyy"
                     },
                     'yyyy.mm.dd': {
                         mask: "y.1.2",
                         placeholder: "yyyy.mm.dd",
                         leapday: ".02.29",
-                        separator: '\.',
+                        separator: '.',
                         alias: "yyyy/mm/dd"
                     },
                     'yyyy-mm-dd': {
                         mask: "y-1-2",
                         placeholder: "yyyy-mm-dd",
                         leapday: "-02-29",
-                        separator: '\-',
+                        separator: '-',
                         alias: "yyyy/mm/dd"
                     },
                     'hh:mm:ss': {
@@ -300,6 +305,10 @@ Optional extentions on the jquery.inputmask base
                     },
                     'hh:mm': {
                         mask: "h:s",
+                        autoUnmask: false
+                    },
+                    'h:s t':{
+                        mask: "h:s t",
                         autoUnmask: false
                     },
                     'date': {

--- a/js/jquery.inputmask.date.extentions.js
+++ b/js/jquery.inputmask.date.extentions.js
@@ -339,7 +339,7 @@ Optional extentions on the jquery.inputmask base
                                         }
                                     }
 
-                                    /*if ( isValid && opts.regex.hrs24.test(chrs) ) {
+                                    if ( isValid && opts.regex.hrs24.test(chrs) ) {
 
                                         var tmp = parseInt(chrs,10);
 
@@ -351,11 +351,7 @@ Optional extentions on the jquery.inputmask base
                                             buffer[pos+6] = "m";
                                         }
 
-                                        console.log("time1:"+tmp+":"+buffer);
-
                                         tmp = tmp - 12;
-
-                                        console.log("time2:"+tmp+":"+buffer);
 
                                         if ( tmp < 10 ) {
                                             buffer[pos] = tmp.toString();
@@ -365,12 +361,8 @@ Optional extentions on the jquery.inputmask base
                                             buffer[pos-1] = tmp.toString().charAt(0);
                                         }
 
-                                        console.log("time3:"+tmp.toString()+":"+buffer);
-
-                                        return pos;
-                                        
-                                        //
-                                    }*/
+                                        return -1;
+                                    }
 
                                     return isValid;
                                 },

--- a/js/jquery.inputmask.date.extentions.js
+++ b/js/jquery.inputmask.date.extentions.js
@@ -313,8 +313,9 @@ Optional extentions on the jquery.inputmask base
                     'h:s t': {
                         mask: "h:s t",
                         regex: {
-                            hrspre: new RegExp("[0-9]"), //hours pre
-                            hrs: new RegExp("0[1-9]|[12][0-9]"), //hours
+                            hrspre: new RegExp("[012]"), //hours pre
+                            hrs24: new RegExp("2[0-9]|1[3-9]"),
+                            hrs: new RegExp("[01][0-9]|2[0-3]"), //hours
                             ampmpre: new RegExp("[apAP]"),
                             ampm: new RegExp("[apAP][mM]")
                         },

--- a/js/jquery.inputmask.date.extentions.js
+++ b/js/jquery.inputmask.date.extentions.js
@@ -67,12 +67,15 @@ Optional extentions on the jquery.inputmask base
                     $input.val(today.getDate().toString() + (today.getMonth() + 1).toString() + today.getFullYear().toString());
                 }
             },
+            transform : function(buffer, position, element){
+                return element.replace(/[\.\-\:]/gi,'/');
+            },
             definitions: {
                 '1': { //val1 ~ day or month
                     validator: function(chrs, buffer, pos, strict, opts) {
                         var isValid = opts.regex.val1.test(chrs);
                         if (!strict && !isValid) {
-                            if (chrs.charAt(1) == opts.separator[opts.separator.length - 1]) {
+                            if (chrs.charAt(1) == opts.separator[opts.separator.length - 1] || "-./".indexOf(chrs.charAt(1)) != -1 ) {
                                 isValid = opts.regex.val1.test("0" + chrs.charAt(0));
                                 if (isValid) {
                                     buffer[pos - 1] = "0";
@@ -103,7 +106,7 @@ Optional extentions on the jquery.inputmask base
                             var frontValue = buffer.join('').substr(0, 3);
                             var isValid = opts.regex.val2(opts.separator).test(frontValue + chrs);
                             if (!strict && !isValid) {
-                                if (chrs.charAt(1) == opts.separator[opts.separator.length - 1]) {
+                                if (chrs.charAt(1) == opts.separator[opts.separator.length - 1] || "-./".indexOf(chrs.charAt(1)) != -1 ) {
                                     isValid = opts.regex.val2(opts.separator).test(frontValue + "0" + chrs.charAt(0));
                                     if (isValid) {
                                         buffer[pos - 1] = "0";

--- a/js/jquery.inputmask.js
+++ b/js/jquery.inputmask.js
@@ -20,6 +20,7 @@ This plugin is based on the masked input plugin written by Josh Bush (digitalbus
                 },
                 escapeChar: "\\",
                 mask: null,
+                rtrim: false,
                 oncomplete: null, //executes when the mask is complete
                 onincomplete: null, //executes when the mask is incomplete and focus is lost
                 oncleared: null, //executes when the mask is cleared
@@ -188,7 +189,7 @@ This plugin is based on the masked input plugin written by Josh Bush (digitalbus
                     else if ((element != opts.optionalmarker.start && element != opts.optionalmarker.end) || escaped) {
                         var maskdef = opts.definitions[element];
                         if (maskdef && !escaped) {
-                            for (i = 0; i < maskdef.cardinality; i++) {
+                            for (var i = 0; i < maskdef.cardinality; i++) {
                                 outElem.push(getPlaceHolder(outCount + i));
                             }
                         } else {
@@ -230,7 +231,7 @@ This plugin is based on the masked input plugin written by Josh Bush (digitalbus
                         var maskdef = opts.definitions[element];
                         if (maskdef && !escaped) {
                             var prevalidators = maskdef["prevalidator"], prevalidatorsL = prevalidators ? prevalidators.length : 0;
-                            for (i = 1; i < maskdef.cardinality; i++) {
+                            for (var i = 1; i < maskdef.cardinality; i++) {
                                 var prevalidator = prevalidatorsL >= i ? prevalidators[i - 1] : [], validator = prevalidator["validator"], cardinality = prevalidator["cardinality"];
                                 outElem.push({ fn: validator ? typeof validator == 'string' ? new RegExp(validator) : new function() { this.test = validator; } : new RegExp("."), cardinality: cardinality ? cardinality : 1, optionality: isOptional, newBlockMarker: isOptional == true ? newBlockMarker : false, offset: 0, casing: maskdef["casing"], def: element });
                                 if (isOptional == true) //reset newBlockMarker
@@ -343,7 +344,11 @@ This plugin is based on the masked input plugin written by Josh Bush (digitalbus
             }
 
             function writeBuffer(input, buffer, caretPos) {
-                input._valueSet(buffer.join(''));
+                if ( opts.rtrim === true ) {
+              	 	input._valueSet(buffer.join('').replace(/\s+$/,""));
+                } else {
+                	input._valueSet(buffer.join(''));
+                }
                 if (caretPos != undefined) {
                     if (android) {
                         setTimeout(function() {

--- a/js/jquery.inputmask.js
+++ b/js/jquery.inputmask.js
@@ -308,7 +308,7 @@ This plugin is based on the masked input plugin written by Josh Bush (digitalbus
                 var elem = element;
 
                 if ( test.transform !== null && elem !== null && elem !== '' ) {
-                    elem = test.transform(buffer,position,element);
+                    elem = test.transform(buffer,position,element,opts);
                 }
 
                 switch (test.casing) {

--- a/js/jquery.inputmask.js
+++ b/js/jquery.inputmask.js
@@ -841,7 +841,7 @@ This plugin is based on the masked input plugin written by Josh Bush (digitalbus
                         setTimeout(function() {
                             caret(input, checkVal(input, buffer, true));
                         }, 0);
-                    } else if (opts.numericInput && e.char == opts.radixPoint[opts.radixPoint.length - 1]) {
+                    } else if (opts.numericInput && e['char'] == opts.radixPoint[opts.radixPoint.length - 1]) {
                         var nptStr = input._valueGet();
                         var radixPosition = nptStr.indexOf(opts.radixPoint[opts.radixPoint.length - 1]);
                         caret(input, seekNext(buffer, radixPosition != -1 ? radixPosition : getMaskLength()));

--- a/js/jquery.inputmask.js
+++ b/js/jquery.inputmask.js
@@ -911,8 +911,10 @@ This plugin is based on the masked input plugin written by Josh Bush (digitalbus
                                 p = seekNext(buffer, pos.begin - 1);
                                 prepareBuffer(buffer, p, isRTL);
                                 if ((np = isValid(p, c, buffer, false)) !== false) {
-                                    if (np !== true) p = np; //set new position from isValid
-                                    if (opts.insertMode === true) shiftR(p, buffer.length, c); else setBufferElement(buffer, p, c);
+                                    if (np !== true && np > -1) p = np; //set new position from isValid
+                                    if ( np > -1 ) {
+                                        if (opts.insertMode === true) shiftR(p, buffer.length, c); else setBufferElement(buffer, p, c);
+                                    }
                                     var next = seekNext(buffer, p);
                                     writeBuffer(input, buffer, next);
 

--- a/js/jquery.inputmask.js
+++ b/js/jquery.inputmask.js
@@ -307,17 +307,19 @@ This plugin is based on the masked input plugin written by Josh Bush (digitalbus
                 var test = tests[determineTestPosition(position)];
                 var elem = element;
 
-                if ( test.transform !== null && elem !== null && elem !== '' ) {
-                    elem = test.transform(buffer,position,element,opts);
-                }
+                if ( test !== undefined ) {
+                    if ( test.transform !== null && elem !== null && elem !== '' ) {
+                        elem = test.transform(buffer,position,element,opts);
+                    }
 
-                switch (test.casing) {
-                    case "upper":
-                        elem = element.toUpperCase();
-                        break;
-                    case "lower":
-                        elem = element.toLowerCase();
-                        break;
+                    switch (test.casing) {
+                        case "upper":
+                            elem = element.toUpperCase();
+                            break;
+                        case "lower":
+                            elem = element.toLowerCase();
+                            break;
+                    }
                 }
 
                 buffer[position] = elem;

--- a/js/jquery.inputmask.js
+++ b/js/jquery.inputmask.js
@@ -770,7 +770,13 @@ This plugin is based on the masked input plugin written by Josh Bush (digitalbus
                     //Safari 5.1.x - modal dialog fires keypress twice workaround
                     skipKeyPressEvent = false;
 
+                    if( $(this).prop('disabled') === true || $(this).prop('readonly') === true ) {
+                        return true;
+                    }
+
                     var input = this, k = e.keyCode, pos = caret(input);
+
+                    
 
                     //set input direction according the position to the radixPoint
                     if (opts.numericInput) {
@@ -870,6 +876,9 @@ This plugin is based on the masked input plugin written by Josh Bush (digitalbus
                     if (e.ctrlKey || e.altKey || e.metaKey || ignorable) {//Ignore
                         return true;
                     } else {
+                        if( $(input).prop('disabled') === true || $(input).prop('readonly') === true ) {
+                            return true;
+                        }
                         if (k) {
                             var pos = caret(input), c = String.fromCharCode(k), maskL = getMaskLength();
                             if (isRTL) {
@@ -909,6 +918,10 @@ This plugin is based on the masked input plugin written by Josh Bush (digitalbus
                 function keyupEvent(e) {
                     var $input = $(this), input = this;
                     var k = e.keyCode;
+                    
+                    if( $input.prop('disabled') === true || $input.prop('readonly') === true ) {
+                        return true;
+                    }
                     opts.onKeyUp.call(this, e, opts); //extra stuff todo on keyup
                     if (k == opts.keyCode.TAB && $input.hasClass('focus.inputmask') && input._valueGet().length == 0) {
                         buffer = _buffer.slice();


### PR DESCRIPTION
Changes to prevent keyboard events from running inputmask if the input is disabled or readonly. 

Sorry, I'm a bit new to git and I may have included multiple commits.
