### PR TITLE
Fix spelling of "extension".

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 jquery.inputmask is a jquery plugin which create an input mask.
 
-Copyright (c) 2010 - 2012 Robin Herbots   
+Copyright (c) 2010 - 2012 Robin Herbots
 Licensed under the MIT license (http://www.opensource.org/licenses/mit-license.php)
 
 The plugin is based on the idea of the maskedinput plugin of Josh Bush (http://digitalbush.com/projects/masked-input-plugin), but has finer control over the 'mask-definitions' and is fully compatible with the ui-datepicker
@@ -49,8 +49,8 @@ Example of some new definitions:
 insertMode: false
 ```
 
-These allow for a finer date validation then 99/99/9999 which also allows 33/33/3333 for example. 
-In the jquery.inputmask.extentions.js you find a full date input validation which takes days, months & leap years into account.
+These allow for a finer date validation then 99/99/9999 which also allows 33/33/3333 for example.
+In the jquery.inputmask.extensions.js you find a full date input validation which takes days, months & leap years into account.
 
 Also extra features like mask-repetitions (greedy and non-gready) and many other additions are included.  In the examples you will find more about them.
 
@@ -62,7 +62,7 @@ Include the js-files:
 ```html
 <script src="jquery.js" type="text/javascript"></script>
 <script src="jquery.inputmask.js" type="text/javascript"></script>
-<script src="jquery.inputmask.extentions.js" type="text/javascript"></script>
+<script src="jquery.inputmask.extensions.js" type="text/javascript"></script>
 ```
 
 Define your masks:
@@ -142,8 +142,8 @@ this can be done with the traditionnal jquery.val function (all browsers) or jav
 
 ```javascript
 $(document).ready(function(){
-   $("#number").val(12345); 
-   
+   $("#number").val(12345);
+
    var number = document.getElementById("number");
    number.value = 12345;
 });
@@ -155,7 +155,7 @@ with the autoUnmaskoption you can change the return of $.fn.val (or value proper
 $(document).ready(function(){
    	$('#<%= tbDate.ClientID%>').inputmask({ "mask": "d/m/y", 'autoUnmask' : true});	//  value: 23/03/1973
 	alert($('#<%= tbDate.ClientID%>').val());	// shows 23031973     (autoUnmask: true)
-	
+
 	var tbDate = document.getElementById("<%= tbDate.ClientID%>");
     alert(tbDate.value);	// shows 23031973     (autoUnmask: true)
 });
@@ -230,7 +230,7 @@ When both the required and optional parts of the mask are filled out and the fie
 
 ### aliases option
 
-First you have to create an alias definition (more examples can be found in jquery.inputmask.extentions.js)
+First you have to create an alias definition (more examples can be found in jquery.inputmask.extensions.js)
 
 ```javascript
 $.extend($.inputmask.defaults.aliases, {
@@ -261,12 +261,12 @@ $(document).ready(function(){
 
 ### auto upper/lower- casing inputmask
 
-see jquery.inputmask.extentions.js for an example how to define "auto"-casing in a definition (definition A)
+see jquery.inputmask.extensions.js for an example how to define "auto"-casing in a definition (definition A)
 casing can be null, "upper" or "lower"
 
 ```javascript
 $(document).ready(function(){
-   $("#test").inputmask("999-AAA");    //   => 123abc ===> 123-ABC 
+   $("#test").inputmask("999-AAA");    //   => 123abc ===> 123-ABC
 });
 ```
 ### getemptymask command
@@ -277,7 +277,7 @@ return the default (empty) mask value
 ```javascript
 $(document).ready(function(){
    $("#test").inputmask("999-AAA");
-   var initialValue = $("#test").inputmask("getemptymask");  // initialValue  => "___-___" 
+   var initialValue = $("#test").inputmask("getemptymask");  // initialValue  => "___-___"
 });
 ```
 
@@ -286,11 +286,11 @@ $(document).ready(function(){
 Use this to do some extra processing of the input when certain keys are pressed.
 This can be usefull when implementing an alias, ex. decimal alias, autofill the digits when pressing tab.
 
-see jquery.inputmask.extentions.js for some examples
+see jquery.inputmask.extensions.js for some examples
 
 
 ## Markup options
-### RTL input 
+### RTL input
 
 Just add the dir="rtl" attribute to the input element
 
@@ -304,7 +304,7 @@ Just add the dir="rtl" attribute to the input element
 First grab the sources from github.  In the root you type ant.
 A new folder dist is created with the minified and optimized js-files
 
-# jquery.inputmask extentions
+# jquery.inputmask extensions
 
 ## Alias definitions
 
@@ -321,10 +321,10 @@ $(document).ready(function(){
 The date aliases take leapyears into account.  There is also autocompletion on day, month, year.
 For example:
 
-input:	2/2/2012 		result: 02/02/2012   
-input:  352012			result: 03/05/2012   
-input:  3530			result: 03/05/2030   
-input: <ctrl> rightarrow	result: the date from today   
+input:	2/2/2012 		result: 02/02/2012
+input:  352012			result: 03/05/2012
+input:  3530			result: 03/05/2030
+input: <ctrl> rightarrow	result: the date from today
 
 ### numeric aliases
 
@@ -332,7 +332,7 @@ input: <ctrl> rightarrow	result: the date from today
 $(document).ready(function(){
    $("#numeric").inputmask("decimal");
    $("#numeric").inputmask("non-negative-decimal");
-   $("#numeric").inputmask("integer"); 
+   $("#numeric").inputmask("integer");
 });
 ```
 

--- a/build.xml
+++ b/build.xml
@@ -11,9 +11,9 @@
     <target name="jquery.inputmask" depends="init">
         <concat destfile="${distdir}/${target}">
 			<fileset file="js/jquery.inputmask.js"/>
-			<fileset file="js/jquery.inputmask.extentions.js"/>
-			<fileset file="js/jquery.inputmask.date.extentions.js"/>
-			<fileset file="js/jquery.inputmask.numeric.extentions.js"/>
+			<fileset file="js/jquery.inputmask.extensions.js"/>
+			<fileset file="js/jquery.inputmask.date.extensions.js"/>
+			<fileset file="js/jquery.inputmask.numeric.extensions.js"/>
         </concat>
     </target>
 
@@ -33,7 +33,7 @@
         </apply>
       	<echo message="${target.min} built." />
     </target>
-    
+
     <target name="minfiles">
       <mkdir dir="${distdir}/min" />
 	<apply executable="java" parallel="false" verbose="true" failonerror="true" dest="${distdir}/min">
@@ -48,9 +48,9 @@
             <targetfile />
             <arg value="--js" />
 	    <mapper type="glob" from="*.js" to="*.js" />
-        </apply>      
+        </apply>
     </target>
-    
+
     <target name="build" depends="jquery.inputmask, jquery.inputmask.min, minfiles"/>
 
     <target name="clean">

--- a/js/jquery.inputmask.date.extensions.js
+++ b/js/jquery.inputmask.date.extensions.js
@@ -1,11 +1,11 @@
 /*
-Input Mask plugin extentions
+Input Mask plugin extensions
 http://github.com/RobinHerbots/jquery.inputmask
 Copyright (c) 2010 - 2012 Robin Herbots
 Licensed under the MIT license (http://www.opensource.org/licenses/mit-license.php)
 Version: 1.0.5
 
-Optional extentions on the jquery.inputmask base
+Optional extensions on the jquery.inputmask base
 */
 (function($) {
     //date & time aliases

--- a/js/jquery.inputmask.extensions.js
+++ b/js/jquery.inputmask.extensions.js
@@ -1,11 +1,11 @@
 /*
-Input Mask plugin extentions
+Input Mask plugin extensions
 http://github.com/RobinHerbots/jquery.inputmask
 Copyright (c) 2010 - 2012 Robin Herbots
 Licensed under the MIT license (http://www.opensource.org/licenses/mit-license.php)
 Version: 1.0.2
 
-Optional extentions on the jquery.inputmask base
+Optional extensions on the jquery.inputmask base
 */
 (function($) {
     //extra definitions

--- a/js/jquery.inputmask.js
+++ b/js/jquery.inputmask.js
@@ -29,7 +29,7 @@
                 clearMaskOnLostFocus: true,
                 insertMode: true, //insert the input or overwrite the input
                 clearIncomplete: false, //clear the incomplete input on blur
-                aliases: {}, //aliases definitions => see jquery.inputmask.extentions.js
+                aliases: {}, //aliases definitions => see jquery.inputmask.extensions.js
                 onKeyUp: $.noop, //override to implement autocomplete on certain keys for example
                 onKeyDown: $.noop, //override to implement autocomplete on certain keys for example
                 //numeric properties
@@ -652,11 +652,11 @@
                  	var events = $._data(npt).events;
 
 					$.each(events, function(eventType, eventHandlers){
-                         $(npt).bind(eventType + ".inputmask", function(event) { 
+                         $(npt).bind(eventType + ".inputmask", function(event) {
                          							if (this.readOnly || this.disabled) {
-                         							  event.stopPropagation(); 
-                         							  event.stopImmediatePropagation(); 
-                         							  event.preventDefault();  
+                         							  event.stopPropagation();
+                         							  event.stopImmediatePropagation();
+                         							  event.preventDefault();
                          							  return false;
                          							}
                          						});
@@ -669,7 +669,7 @@
                          eventHandlers[0] = ourHandler;
                     });
 				}
-                               
+
                 function patchValueProperty(npt) {
                     var valueProperty;
                     if (Object.getOwnPropertyDescriptor)
@@ -962,4 +962,4 @@
             }
         };
     }
-})(jQuery); 
+})(jQuery);

--- a/js/jquery.inputmask.numeric.extensions.js
+++ b/js/jquery.inputmask.numeric.extensions.js
@@ -1,14 +1,14 @@
 /*
-Input Mask plugin extentions
+Input Mask plugin extensions
 http://github.com/RobinHerbots/jquery.inputmask
 Copyright (c) 2010 - 2012 Robin Herbots
 Licensed under the MIT license (http://www.opensource.org/licenses/mit-license.php)
 Version: 1.0.4
 
-Optional extentions on the jquery.inputmask base
+Optional extensions on the jquery.inputmask base
 */
             (function($) {
-                //number aliases 
+                //number aliases
                 //$.extend($.inputmask.defaults.definitions, {
                 //    '9': {
                 //        validator: function(chrs, buffer, pos, strict, opts) {
@@ -20,7 +20,7 @@ Optional extentions on the jquery.inputmask base
                 //        },
                 //        cardinality: 1,
                 //        regex: new RegExp("[0-9]")
-                //    }                    
+                //    }
                 //});
                 $.extend($.inputmask.defaults.aliases, {
                     'decimal': {


### PR DESCRIPTION
"extention", as used throughout this plugin, is not correct English -- the proper spelling is "extension". I've fixed it.
