### PR TITLE
Clearing optional tail on mask assignment

### DIFF
--- a/js/jquery.inputmask.js
+++ b/js/jquery.inputmask.js
@@ -669,8 +669,13 @@
                 if (document.activeElement === el) { //position the caret when in focus
                     $input.addClass('focus.inputmask');
                     caret(el, lastPosition);
-                } else if (opts.clearMaskOnLostFocus && el._valueGet() == _buffer.join(''))
-                    el._valueSet('');
+                } else if (opts.clearMaskOnLostFocus) {
+                    if (el._valueGet() == _buffer.join('')) {
+                        el._valueSet('');  
+                    } else {
+                        clearOptionalTail(el, buffer);  
+                    }
+                }
 
                 installEventRuler(el);
 


### PR DESCRIPTION
Fixing an issue when a mask is set with an optional tail and clearMaskOnLostFocus is true the tail still shows up for the input field until a blur or mouseleave event is fired. An example of a phone number with optional extension can be seen here http://jsfiddle.net/e4qBb/.
