### PR TITLE
Special handling in numeric of first character when value is "0"

### DIFF
--- a/js/jquery.inputmask.numeric.extensions.js
+++ b/js/jquery.inputmask.numeric.extensions.js
@@ -53,6 +53,10 @@ Optional extensions on the jquery.inputmask base
                         var cbuf = buffer.slice();
                         cbuf.splice(pos, 0, chrs);
                         var bufferStr = cbuf.join('');
+                        if (/^0[\d|-]$/.test(bufferStr)) { //handle first char
+                            buffer[0]= "";
+                            return { "pos": 1, "c": "" };
+                        }
                         var isValid = opts.regex.number(separatorExpression(), opts.groupSize, radixPointExpression(), digitExpression()).test(bufferStr);
                         if (!isValid) {
                             if (strict) { //shiftL & shiftR use strict only validate from 0 to position


### PR DESCRIPTION
Fix Issues #113 and #121 - handle the first character entered so that negatives or numbers replace an existing '0'
