### PR TITLE
Change event not firing when "decimal" input mask used under certain conditions

### DIFF
--- a/js/jquery.inputmask.numeric.extensions.js
+++ b/js/jquery.inputmask.numeric.extensions.js
@@ -36,7 +36,7 @@ Optional extensions on the jquery.inputmask base
                         }
                         if (nptStr !== $input.val()) {
                         	$input.val(nptStr);
-						}
+                        }
                     }
                 }
             },

--- a/js/jquery.inputmask.numeric.extensions.js
+++ b/js/jquery.inputmask.numeric.extensions.js
@@ -34,7 +34,9 @@ Optional extensions on the jquery.inputmask base
                         for (var i = 1; i < opts.digits; i++) {
                             if (nptStr[radixPosition + i]) nptStr = nptStr + "0";
                         }
-                        $input.val(nptStr);
+                        if (nptStr !== $input.val()) {
+                        	$input.val(nptStr);
+						}
                     }
                 }
             },


### PR DESCRIPTION
When a decimal input field is used, the field has a "." character, and the user TABs out, no change event is fired.

[Demo of the bug](http://jsbin.com/emozaj/2/edit)

[Demo of the fix](http://jsbin.com/emozaj/3/edit)

The reason is because this line in the numeric extensions will cause `$input.val` to be set to itself if the previous lines do not add any trailing 0s:

``` js
$input.val(nptStr);                            
```

This causes the undo buffer to be set to the value that was just entered by the user.  Then in inputmask line 596:

``` js
if (nptValue != undoBuffer) {
    $input.change();
}
```

Since the value is the same as the buffer, no change event is fired.

The fix is to only set the input value if there was actually a change.

Note also that in the above demos, if you tab out, the first character gets truncated from the input.  Not sure if this is an issue with tab key binding conflict in JSBin or not... the same thing happend in jsfiddle.
