### PR TITLE
Fix for Firefox error when calling 'setSelectionRange' on hidden elements

### DIFF
--- a/js/jquery.inputmask.js
+++ b/js/jquery.inputmask.js
@@ -649,6 +649,9 @@
             }
 
             function caret(input, begin, end) {
+                if (!$(input).is(':visible')) {
+                    return;
+                }
                 var npt = input.jquery && input.length > 0 ? input[0] : input;
                 if (typeof begin == 'number') {
                     end = (typeof end == 'number') ? end : begin;


### PR DESCRIPTION
Simple as it sounds. 

Firefox explodes when trying to change the caret's position if the element is hidden.

This is a simple fix.
