### PR TITLE
Fixed bug when trying to remove mask placeholders

### DIFF
--- a/js/jquery.inputmask.js
+++ b/js/jquery.inputmask.js
@@ -1072,7 +1072,7 @@
                             clearBuffer(buffer, pos.begin, pos.end);
                             determineActiveMasksetIndex(buffer, pos.begin, activeMasksetIndex);
                             writeBuffer(input, buffer);
-                            caret(isRTL ? checkVal(input, buffer, false) : pos.begin);
+                            caret(input, isRTL ? checkVal(input, buffer, false) : pos.begin);
                         } else { //handle delete
                             var beginPos = pos.begin;
                             if (k == opts.keyCode.DELETE) {


### PR DESCRIPTION
If placeholders are shown in input and you select something that includes those placeholders, error is thrown. This seems to be because in caret function call the actual input is missing. Added that to the function call.
