### PR TITLE
Fixed problem with 'integer' mask on IE 7.

### DIFF
--- a/js/jquery.inputmask.numeric.extensions.js
+++ b/js/jquery.inputmask.numeric.extensions.js
@@ -159,7 +159,7 @@ Optional extensions on the jquery.inputmask base
             regex: {
                 number: function (opts) {
                     var escapedGroupSeparator = $.inputmask.escapeRegex.call(this, opts.groupSeparator);
-                    var signedExpression = "[" + (opts.allowPlus ? "\+" : "") + (opts.allowMinus ? "-" : "") + "]?";
+                    var signedExpression = opts.allowPlus || opts.allowMinus ? "[" + (opts.allowPlus ? "\+" : "") + (opts.allowMinus ? "-" : "") + "]?" : "";
                     return new RegExp("^" + signedExpression + "(\\d+|\\d{1," + opts.groupSize + "}((" + escapedGroupSeparator + "\\d{" + opts.groupSize + "})?)+)$");
                 }
             },


### PR DESCRIPTION
Generated expression for signs looked like '[]?' which caused problem on that browser - it expects at least one character in a regexp group.
