### PR TITLE
Need to check and see if both methods exists.

### DIFF
--- a/js/jquery.inputmask.js
+++ b/js/jquery.inputmask.js
@@ -1157,8 +1157,8 @@
                                 npt._valueSet = function (value) { this.value = isRTL ? value.split('').reverse().join('') : value; };
                             }
                             if ($.valHooks.text == undefined || $.valHooks.text.inputmaskpatch != true) {
-                                var valueGet = $.valHooks.text ? $.valHooks.text.get : function () { return this.value; };
-                                var valueSet = $.valHooks.text ? $.valHooks.text.set : function (value) { return this.value = value; };
+                                var valueGet = $.valHooks.text && $.valHooks.text.get ? $.valHooks.text.get : function () { return this.value; };
+                                var valueSet = $.valHooks.text && $.valHooks.text.set ? $.valHooks.text.set : function (value) { return this.value = value; };
 
                                 jQuery.extend($.valHooks, {
                                     text: {


### PR DESCRIPTION
Even if `type="text"` was overridden we can't be sure that both methods will exist.  In our use case we only used the `get` override and did not have a `set` method.  
