### PR TITLE
Update jquery.inputmask.js

### DIFF
--- a/js/jquery.inputmask.js
+++ b/js/jquery.inputmask.js
@@ -754,7 +754,7 @@
 
                     npt.scrollLeft = npt.scrollWidth;
                     if (opts.insertMode == false && begin == end) end++; //set visualization for insert/overwrite mode
-                    if (npt.setSelectionRange) {
+                    if (npt.setSelectionRange &&  $(npt).is(":focus") == true) { 
                         npt.selectionStart = begin;
                         npt.selectionEnd = end;
 
@@ -1445,7 +1445,7 @@
 
                     npt.scrollLeft = npt.scrollWidth;
                     if (opts.insertMode == false && begin == end) end++; //set visualization for insert/overwrite mode
-                    if (npt.setSelectionRange) {
+                    if (npt.setSelectionRange &&  $(npt).is(":focus") == true) { 
                         npt.selectionStart = begin;
                         npt.selectionEnd = end;
 


### PR DESCRIPTION
The code in mcaret is being executed in Chrome during initialization of inputmask which causes the cursor to be positioned in the input box(every time .inputmask() is called).  Positioning the cursor in the input box gives focus to the item and raises the focus event.  I was not able to recreate with JSFiddle but was able to do it with a local html file.  From what I see there is no reason to set the cursor's position if the item does not have focus.  In the code bellow I see the last datepicker being opened and the last input box retaining focus on load.

<html>
<head>

<script src="http://code.jquery.com/jquery-1.9.1.js"></script>

<script src="http://code.jquery.com/ui/1.9.2/jquery-ui.js" ></script>

<script src="https://rawgit.com/RobinHerbots/jquery.inputmask/3.x/dist/jquery.inputmask.bundle.js"></script>

<link href="http://code.jquery.com/ui/1.9.2/themes/base/jquery-ui.css" rel="stylesheet" type="text/css">
</head>
<body>
<input type="text" id="date">
<input type="text" id="date1">
<input type="text" id="date2">

<script type="text/javascript">
$("#date").datepicker();
$("#date").inputmask("mm/dd/yyyy");
$("#date1").datepicker();
$("#date1").inputmask("mm/dd/yyyy");
$("#date2").inputmask("999-999-9999");
</script>

</body>
</html>
