### PR TITLE
Input gets focus on .val

### DIFF
--- a/js/jquery.inputmask.js
+++ b/js/jquery.inputmask.js
@@ -753,7 +753,7 @@
                     data["caret"] = { "begin": begin, "end": end };
                     $(npt).data('_inputmask', data);
 
-                    if (!$(npt).is(":visible")) {
+                    if (!$(npt).is(":visible") || !$(input).is(":focus")) {
                         return;
                     }
 


### PR DESCRIPTION
thanks for the quick turnaround on this fix, noticed one more inconsistency if focus checking is removed.

Calling .val() after .inputmask() still causes the unexpected behavior of giving the input focus when it shouldn't necessarily have it.  Since I could not recreate in JSFiddle bellow is the html to reproduce. 

``` html
<html>
<head>


<script src="http://code.jquery.com/jquery-1.9.1.js"></script>
<script src="http://code.jquery.com/ui/1.9.2/jquery-ui.js" ></script>
<script src="https://rawgit.com/RobinHerbots/jquery.inputmask/3.x/dist/jquery.inputmask.bundle.js"></script>
<link href="http://code.jquery.com/ui/1.9.2/themes/base/jquery-ui.css" rel="stylesheet" type="text/css">
</head>
<body>
<input type="text" id="date">
<input type="text" id="date1">
<input type="text" id="date2">

<script type="text/javascript">
$("#date").datepicker();
$("#date").inputmask("mm/dd/yyyy");
$("#date1").datepicker();
$("#date1").inputmask("mm/dd/yyyy");
$("#date1").val("11/31/2012");
$("#date2").inputmask("999-999-9999");
$("#date2").val("999-999-99");
</script>
</body>
</html>
```
