### PR TITLE
Don't distribute tests and build tools w/ bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,15 +1,24 @@
 {
-    "name": "jquery.inputmask",
-    "version": "3.0.48",
-    "main": "./dist/jquery.inputmask.bundle.js",
-	"keywords" : ["jQuery", "plugins", "input", "form", "inputmask", "mask"],
-	"description": "jquery.inputmask is a jquery plugin which create an input mask.",
-	"license": "http://opensource.org/licenses/mit-license.php",
-    "dependencies": {
-        "jquery": ">=1.7"
-    },
-	"authors": [ 
-		{ "name": "Robin Herbots" }
-	],
-	"homepage": "http://robinherbots.github.io/jquery.inputmask"
+  "name": "jquery.inputmask",
+  "version": "3.0.48",
+  "main": "./dist/jquery.inputmask.bundle.js",
+  "keywords" : ["jQuery", "plugins", "input", "form", "inputmask", "mask"],
+  "description": "jquery.inputmask is a jquery plugin which create an input mask.",
+  "license": "http://opensource.org/licenses/mit-license.php",
+  "ignore": [
+    "qunit/",
+    "nuget/",
+    "tools/",
+    "js/",
+    "README.md",
+    "build.properties",
+    "build.xml"
+  ],
+  "dependencies": {
+      "jquery": ">=1.7"
+  },
+  "authors": [ 
+    { "name": "Robin Herbots" }
+  ],
+  "homepage": "http://robinherbots.github.io/jquery.inputmask"
 }


### PR DESCRIPTION
When installing with bower, this repo includes a bunch of files that aren't really necessary for use as a JS lib. Using the ignore option, these files can be excluded from the package.

```
12k   ./nuget
7.7M  ./tools
56K   ./dist/min
280K  ./dist
52K   ./js/phone-codes
212K  ./js
84K   ./qunit
8.4M  .
```
