### PR TITLE
Added a Gruntfile to enable building a complete file with r.js. Fixes #591

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ jquery-1.10.2.js
 dist/jQuery.InputMask.*.nupkg
 node_modules/
 bower_components/
+.idea/
+*.iml

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,43 @@
+module.exports = function (grunt) {
+  grunt.initConfig({
+    pkg: grunt.file.readJSON('package.json'),
+    requirejs: {
+      compile: {
+        options: {
+          name: 'jquery.inputmask',
+          paths: {
+            jquery: 'empty:'
+          },
+          include: [
+            'jquery.inputmask.extensions',
+            'jquery.inputmask.date.extensions',
+            'jquery.inputmask.numeric.extensions',
+            'jquery.inputmask.regex.extensions',
+            'jquery.inputmask.phone.extensions'
+          ],
+          baseUrl: 'js',
+          out: 'dist/jquery.inputmask.amdbundle.js',
+          optimize: 'none',
+          onModuleBundleComplete: function (data) {
+            var fs = require('fs'),
+              amdclean = require('amdclean'),
+              outputFile = data.path;
+
+            fs.writeFileSync(outputFile, amdclean.clean({
+              filePath: outputFile,
+              transformAMDChecks: false
+            }));
+          }
+        }
+      }
+    },
+    qunit: {
+      files: ['qunit/qunit.html']
+    }
+  });
+  grunt.loadNpmTasks('grunt-contrib-qunit');
+  grunt.loadNpmTasks('grunt-contrib-requirejs');
+  grunt.registerTask('test', ['qunit']);
+  grunt.registerTask('build', ['requirejs']);
+  grunt.registerTask('default', ['test', 'build']);
+};

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "./dist/inputmask/jquery.inputmask.regex.extensions.js"
   ],
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "grunt test"
   },
   "repository": {
     "type": "git",
@@ -36,6 +36,10 @@
     "jquery": ">=1.7"
   },
   "devDependencies": {
+    "amdclean": "~2.2.4",
+    "grunt": "~0.4.5",
+    "grunt-contrib-qunit": "~0.5.2",
+    "grunt-contrib-requirejs": "~0.4.4",
     "jquery": ">=1.7"
   }
 }


### PR DESCRIPTION
Hi!

I thought I'd give a (very) quick whack at this. It seems to work fairly well. Quite a few tests fails (both with phantom and in the browser), but I haven't looked at why.

I spent like 30 minutes on this (new to Grunt), so it's probably possible to do it better and more cleanly than this. but it's a start at least, and I have no problem tweaking it before a possible merge.

This should make it easier to add linting and all that good stuff as well. Maybe auto-building on Travis. (this ties into #605)

I also left out the built file, just run `npm install && grunt builld` (just calling grunt runs the tests, and some fail).
