### PR TITLE
Move jQuery dependency to peerDependencies and add David-badges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 test.html
 jquery-1.10.2.js
 dist/jQuery.InputMask.*.nupkg
+node_modules/

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 Copyright (c) 2010 - 2014 Robin Herbots
 Licensed under the MIT license (http://opensource.org/licenses/mit-license.php)
 
+[![Dependency Status](https://david-dm.org/RobinHerbots/jquery.inputmask.svg)](https://david-dm.org/RobinHerbots/jquery.inputmask) [![devDependency Status](https://david-dm.org/RobinHerbots/jquery.inputmask/dev-status.svg)](https://david-dm.org/RobinHerbots/jquery.inputmask#info=devDependencies) [![peerDependency Status](https://david-dm.org/RobinHerbots/jquery.inputmask/peer-status.svg)](https://david-dm.org/RobinHerbots/jquery.inputmask#info=peerDependencies)
+
 jquery.inputmask is a jQuery plugin which create an input mask.
 
 An inputmask helps the user with the input by ensuring a predefined format. This can be useful for dates, numerics, phone numbers, ...

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "main": [
     "./dist/inputmask/jquery.inputmask.js",
     "./dist/inputmask/jquery.inputmask.extensions.js",
-	"./dist/inputmask/jquery.inputmask.date.extensions.js",
-	"./dist/inputmask/jquery.inputmask.numeric.extensions.js",
-	"./dist/inputmask/jquery.inputmask.phone.extensions.js",
-	"./dist/inputmask/jquery.inputmask.regex.extensions.js"
+    "./dist/inputmask/jquery.inputmask.date.extensions.js",
+    "./dist/inputmask/jquery.inputmask.numeric.extensions.js",
+    "./dist/inputmask/jquery.inputmask.phone.extensions.js",
+    "./dist/inputmask/jquery.inputmask.regex.extensions.js"
   ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -32,7 +32,10 @@
     "url": "https://github.com/RobinHerbots/jquery.inputmask/issues"
   },
   "homepage": "https://github.com/RobinHerbots/jquery.inputmask",
-  "dependencies": {
+  "peerDependencies": {
+    "jquery": ">=1.7"
+  },
+  "devDependencies": {
     "jquery": ">=1.7"
   }
 }


### PR DESCRIPTION
As a plugin you should have your jQuery-dependency as a peerDependency.
jQuery should also be a devDependency, as it's used when running tests.

Source: http://blog.nodejs.org/2013/02/07/peer-dependencies/

In addition I added the nice dependency-badges from https://david-dm.org
