### PR TITLE
Fixed: On google chrome, cannot use jquery to clone the inputmask control with data and events

### DIFF
--- a/js/jquery.inputmask.js
+++ b/js/jquery.inputmask.js
@@ -965,6 +965,8 @@
                 return placeholder != undefined ? placeholder : (test["fn"] == null ? test["def"] : opts.placeholder.charAt(pos % opts.placeholder.length));
             }
             function checkVal(input, writeOut, strict, nptvl) {
+				if (typeof input._valueGet === 'undefined' || !$.isFunction(input._valueGet))
+					return;
                 var inputValue = nptvl != undefined ? nptvl.slice() : input._valueGet().split('');
                 resetMaskSet();
                 if (writeOut) input._valueSet(""); //initial clear
@@ -1691,6 +1693,8 @@
                     }).bind(PasteEventType + ".inputmask dragdrop.inputmask drop.inputmask", pasteEvent
                     ).bind('setvalue.inputmask', function () {
                         var input = this;
+						if (typeof input._valueGet === 'undefined' || !$.isFunction(input._valueGet))
+							return;
                         checkVal(input, true, false);
                         valueOnFocus = getBuffer().join('');
                         if ((opts.clearMaskOnLostFocus || opts.clearIncomplete) && input._valueGet() == getBufferTemplate().join(''))


### PR DESCRIPTION
Lets say if we already had an inputmask control. Then, at the run-time, using jquery to clone the control like this:

// Clone with data and events
var $clone = $("#inputmask").clone(true);
// Clear the old value
$clone.val("");
// Append the cloned control
$("#div").append($clone);

Firefox is fined, but Chrome (Version 38.0.2125.111 m - the latest version) will throw an error and the control cannot be copied. See the attached images for more details. Thankyou!

![h1](https://cloud.githubusercontent.com/assets/9220521/4888697/69fffe5a-638f-11e4-96f1-37ff506b5c3b.png)
![h2](https://cloud.githubusercontent.com/assets/9220521/4888703/6f8092b8-638f-11e4-9ec1-45bc262a79f9.png)
