### PR TITLE
IE 9, KnockoutJS Binding Problem

### DIFF
--- a/js/jquery.inputmask.js
+++ b/js/jquery.inputmask.js
@@ -1445,7 +1445,11 @@
                             $input.prop("title", getMaskSet()["mask"]);
                         }
 
-                        if (e) e.preventDefault();
+                        if (e) {
+                            if (e.preventDefault)
+                                e.preventDefault();
+                        }
+                        
                         if (checkval) {
                             var keyResult = opts.onKeyPress.call(this, e, getBuffer(), forwardPosition, opts);
                             if (keyResult && keyResult["refreshFromBuffer"]) {


### PR DESCRIPTION
Binding an ObservableArray with Mask bound items, the binding manager was throwing an error that it didn't like a the e.preventDefault.  Adjusted it to check for this method, and then bind.  This fixed my issue in IE9.
