### PR TITLE
Disables paste

### DIFF
--- a/js/jquery.inputmask.js
+++ b/js/jquery.inputmask.js
@@ -1546,7 +1546,16 @@
                     }
                 }
 
-                var pasteValue = $.isFunction(opts.onBeforePaste) ? (opts.onBeforePaste.call(input, inputValue, opts) || inputValue) : inputValue;
+                var pasteValue = inputValue;
+                if($.isFunction(opts.onBeforePaste)) {
+                    pasteValue = opts.onBeforePaste.call(input, inputValue, opts);
+                    if (pasteValue === false) {
+                        e.preventDefault();
+                        return false;
+                    }
+                    if (!pasteValue)
+                        pasteValue = inputValue;
+                }
                 checkVal(input, true, false, isRTL ? pasteValue.split('').reverse() : pasteValue.split(''));
                 $input.click();
                 if (isComplete(getBuffer()) === true)


### PR DESCRIPTION
Disable paste for the user. for example

$("#test").inputmask('9999', {onBeforePaste: function (pastedValue) { return false; }})

The user can't paste in the control.
