### PR TITLE
Add CommonJS support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+
+[*.js]
+indent_style = tab
+indent_size = 4
+
+[*.json]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ dist/jQuery.InputMask.*.nupkg
 node_modules/
 bower_components/
 npm-debug.log
+.idea/
+*.iml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [unpublished]
+### Added
+- Support for CommonJS (Browserify)
+
 ## [3.1.62] - 2015-03-26
 ### Added
 - Numeric alias: add unmaskAsNumber option

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -49,10 +49,22 @@ module.exports = function (grunt) {
             return srcFile.replace(new RegExp("\\(jQuery\\).*$"), "");
         }
 
+        function createCommonJsRequires(dependencies) {
+            var res = [];
+
+            dependencies.forEach(function (dep) {
+                res.push("require('" + dep + "')");
+            });
+
+            return res.join(", ");
+        }
+
         var srcFile = grunt.file.read(src),
             dstContent = "(function (factory) {" +
                 "if (typeof define === 'function' && define.amd) {" +
                 "define(" + JSON.stringify(dependencies) + ", factory);" +
+                "} else if (typeof exports === 'object') {" +
+                "module.exports = factory(" + createCommonJsRequires(dependencies) + ");" +
                 "} else {" +
                 "factory(jQuery);" +
                 "}}\n" + stripClosureExecution() + ");";

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Copyright (c) 2010 - 2015 Robin Herbots
 Licensed under the MIT license (http://opensource.org/licenses/mit-license.php)
 
-[![devDependency Status](https://david-dm.org/RobinHerbots/jquery.inputmask/dev-status.svg)](https://david-dm.org/RobinHerbots/jquery.inputmask#info=devDependencies) [![peerDependency Status](https://david-dm.org/RobinHerbots/jquery.inputmask/peer-status.svg)](https://david-dm.org/RobinHerbots/jquery.inputmask#info=peerDependencies)
+[![Dependency Status](https://david-dm.org/RobinHerbots/jquery.inputmask.svg)](https://david-dm.org/RobinHerbots/jquery.inputmask) [![devDependency Status](https://david-dm.org/RobinHerbots/jquery.inputmask/dev-status.svg)](https://david-dm.org/RobinHerbots/jquery.inputmask#info=devDependencies)
 
 jquery.inputmask is a jQuery plugin which create an input mask.
 
@@ -25,7 +25,7 @@ Highlights:
 - dynamic-mask support
 - preprocessing-mask support
 - value formatting / validating without input element
-- AMD support
+- AMD/CommonJS support
 
 Demo page see http://robinherbots.github.io/jquery.inputmask
 

--- a/package.json
+++ b/package.json
@@ -3,8 +3,16 @@
   "version": "3.1.62",
   "description": "jquery.inputmask is a jquery plugin which create an input mask.",
   "main": "./dist/inputmask/jquery.inputmask.js",
+  "files": [
+      "dist/inputmask/jquery.inputmask.js",
+      "dist/inputmask/jquery.inputmask.extensions.js",
+      "dist/inputmask/jquery.inputmask.date.extensions.js",
+      "dist/inputmask/jquery.inputmask.numeric.extensions.js",
+      "dist/inputmask/jquery.inputmask.phone.extensions.js",
+      "dist/inputmask/jquery.inputmask.regex.extensions.js"
+  ],
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "grunt qunit"
   },
   "repository": {
     "type": "git",
@@ -27,7 +35,7 @@
     "url": "https://github.com/RobinHerbots/jquery.inputmask/issues"
   },
   "homepage": "https://github.com/RobinHerbots/jquery.inputmask",
-  "peerDependencies": {
+  "dependencies": {
     "jquery": ">=1.7"
   },
   "devDependencies": {
@@ -35,10 +43,9 @@
     "grunt-bump": "^0.3.0",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-qunit": "^0.5.2",
-    "grunt-contrib-uglify": "^0.8.0",
-    "grunt-nuget": "^0.1.3",
+    "grunt-contrib-uglify": "^0.8.1",
+    "grunt-nuget": "^0.1.4",
     "grunt-release": "^0.12.0",
-    "grunt-shell": "^1.1.1",
-    "jquery": ">=1.7"
+    "grunt-shell": "^1.1.2"
   }
 }


### PR DESCRIPTION
Hi again!

As the jquery plugin registry has become read-only, the way to distribute jquery plugins is officially by npm (http://plugins.jquery.com/).

The way npm modules work, is by using CommonJS, and not AMD. So I added support for that module format as well.

The tests fails for me, btw, using Linux.

I also added an .editorconfig, as my IDE kept stripping trailing comments in markdown files...

Btw, the thing you asked about in https://github.com/RobinHerbots/jquery.inputmask/pull/620#issuecomment-52471906 is possible with Browserify (or Webpack that I've moved to). It looks in node_modules :smile: 
