### PR TITLE
Fix disappearing placeholders in <= IE9

### DIFF
--- a/js/jquery.inputmask.js
+++ b/js/jquery.inputmask.js
@@ -1837,7 +1837,7 @@
                                 var buffer = getBuffer().slice(), nptValue = input._valueGet();
                                 if (!$input.is(":focus") && nptValue != $input.attr("placeholder") && nptValue != '') {
                                     if (nptValue == getBufferTemplate().join(''))
-                                        buffer = [];
+                                        buffer = [$input.attr("placeholder")];
                                     else { //clearout optional tail of the mask
                                         clearOptionalTail(buffer);
                                     }

--- a/js/jquery.inputmask.js
+++ b/js/jquery.inputmask.js
@@ -1837,7 +1837,7 @@
                                 var buffer = getBuffer().slice(), nptValue = input._valueGet();
                                 if (!$input.is(":focus") && nptValue != $input.attr("placeholder") && nptValue != '') {
                                     if (nptValue == getBufferTemplate().join(''))
-                                        buffer = [$input.attr("placeholder")];
+                                        buffer = [$input.attr("placeholder").slice()];
                                     else { //clearout optional tail of the mask
                                         clearOptionalTail(buffer);
                                     }


### PR DESCRIPTION
In IE9, if you mouseover a field with a placeholder value and then mouse out, your placeholder disappears and the field is empty. This fix instead will set the value of the field to the value of the placeholder if the field remains untouched.

Added slice to placeholder since buffer expects an array of chars.
