### PR TITLE
fix caret does not restore its position on focus in IE

### DIFF
--- a/js/jquery.inputmask.js
+++ b/js/jquery.inputmask.js
@@ -1870,6 +1870,8 @@
                             if (input._valueGet() != getBuffer().join('')) {
                                 writeBuffer(input, getBuffer(), seekNext(getLastValidPosition()));
                             }
+                        } else {
+                          caret(input, seekNext(getLastValidPosition()));
                         }
                         undoValue = getBuffer().join('');
                     }).bind("mouseleave.inputmask", function () {


### PR DESCRIPTION
It happens in IE > 7 versions. E.g. http://jsbin.com/kocoqamuci/1/
