### PR TITLE
Bugfix for unresolved variable $input

### DIFF
--- a/js/inputmask.js
+++ b/js/inputmask.js
@@ -1639,7 +1639,7 @@
 						if (unmaskedValue !== null) {
 							var bufferValue = (isRTL ? getBuffer().slice().reverse() : getBuffer()).join("");
 							if ($.isFunction(opts.onUnMask)) {
-								unmaskedValue = (opts.onUnMask.call($input, bufferValue, unmaskedValue, opts) || unmaskedValue);
+								unmaskedValue = (opts.onUnMask.call(input, bufferValue, unmaskedValue, opts) || unmaskedValue);
 							}
 						}
 						return unmaskedValue;


### PR DESCRIPTION
`$input` variable is undefined in `unmaskedvalue` function at line 1642.
