### PR TITLE
fix element validation for the vanilla dependencyLib

### DIFF
--- a/extra/dependencyLibs/inputmask.dependencyLib.js
+++ b/extra/dependencyLibs/inputmask.dependencyLib.js
@@ -81,7 +81,7 @@ Licensed under the MIT license (http://www.opensource.org/licenses/mit-license.p
 		}();
 
 		function isValidElement(elem) {
-			return elem !== undefined && elem !== null && document.getElementById(elem.id);
+			return elem instanceof Element;
 		}
 
 		function Event(elem) {


### PR DESCRIPTION
Sometimes target element hasn't `id`. Checking target for Element interface implementation seems more preferable.

It also fixes my problem in https://github.com/RobinHerbots/jquery.inputmask/issues/517
