### PR TITLE
Fix for issue #1073

### DIFF
--- a/js/inputmask.js
+++ b/js/inputmask.js
@@ -2314,7 +2314,7 @@
 
 				//backspace in chrome32 only fires input event - detect & treat
 				var caretPos = caret(input),
-					currentValue = input._valueGet();
+					currentValue = input.inputmask._valueGet();
 
 				currentValue = currentValue.replace(new RegExp("(" + Inputmask.escapeRegex(getBufferTemplate().join("")) + ")*"), "");
 				//correct caretposition for chrome


### PR DESCRIPTION
I got this error when debugging in the stock Android browser on a Samsung Galaxy S4 running Android 5.0.1.

```
Uncaught TypeError: undefined is not a function
```

Upon investigation, the code is trying to execute _valueGet() on the input object, but the _valueGet() is a property of the inputmask object, not the input object.
