### PR TITLE
Fix for modified Android Keyboards

### DIFF
--- a/js/inputmask.js
+++ b/js/inputmask.js
@@ -1727,7 +1727,9 @@
 
 				$.each(inputValue, function(ndx, charCode) {
 					var keypress = new $.Event("keypress");
-					keypress.which = charCode.charCodeAt(0);
+					if (charCode !== undefined) {
+						keypress.which = charCode.charCodeAt(0);
+					}
 					charCodes += charCode;
 					var lvp = getLastValidPosition(undefined, true),
 						lvTest = getMaskSet().validPositions[lvp],


### PR DESCRIPTION
Some Android keyboards from Samsung and Sony get some delay to respond to a function, and sometimes (cheaper samsung always) pass charCode undefined.

This issue makes character jump in mask placeholder like space or dot, and at end not being inserted at input.
