### PR TITLE
fixed "valids is not defined" error

### DIFF
--- a/js/inputmask.js
+++ b/js/inputmask.js
@@ -791,8 +791,10 @@
 			}
 
 			function getLastValidPosition(closestTo, strict) {
-				var before = -1,
-					after = -1;
+				var
+					before = -1,
+					after = -1,
+					valids;
 				valids = getMaskSet().validPositions;
 				if (closestTo === undefined) closestTo = -1;
 				for (var posNdx in valids) {


### PR DESCRIPTION
In 3.2.6 there is an error regarding "valids" variable which breaks inputmask.js in runtime. Just defined it.
