### PR TITLE
Update package.json 'files' to include extra/bindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "./dist/inputmask/jquery.inputmask.js",
   "files": [
     "dist/inputmask/",
+    "extra/bindings",
     "extra/dependencyLibs/",
     "extra/phone-codes/",
     "dist/jquery.inputmask.bundle.js"

--- a/package.json
+++ b/package.json
@@ -5,9 +5,7 @@
   "main": "./dist/inputmask/jquery.inputmask.js",
   "files": [
     "dist/inputmask/",
-    "extra/bindings",
-    "extra/dependencyLibs/",
-    "extra/phone-codes/",
+    "extra/",
     "dist/jquery.inputmask.bundle.js"
   ],
   "scripts": {


### PR DESCRIPTION
If you download the files with npm, the "bindings" directory was not included in "extra" set of files because it was missing in the "files" list in package.json

This patch makes it available.
