### PR TITLE
date.extensions: maxyear current or future fix

### DIFF
--- a/js/inputmask.date.extensions.js
+++ b/js/inputmask.date.extensions.js
@@ -107,7 +107,14 @@ Optional extensions on the jquery.inputmask base
 						var maxxYear = maxYearPrefix + maxYearPostfix;
 						return minyear > maxxYear ? minyear : maxxYear;
 					}
-
+					if (minyear <= currentyear && currentyear <= maxyear) {
+						var currentYearPrefix = currentyear.toString().slice(0, 2);
+						while (maxyear < currentYearPrefix + hint) {
+							currentYearPrefix--;
+						}
+						var currentYearAndHint = currentYearPrefix + hint;
+						return currentYearAndHint < minyear ? minyear : currentYearAndHint;
+					}
 					return currentyear;
 				},
 				onKeyDown: function(e, buffer, caretPos, opts) {

--- a/qunit/tests_date.js
+++ b/qunit/tests_date.js
@@ -304,4 +304,89 @@ define([
 
 
 	});
+
+	qunit.test("inputmask(\"dd/mm/yyyy\", { yearrange: { minyear: 1900, maxyear: 2016 } })", function(assert) {
+		var $fixture = $("#qunit-fixture");
+		$fixture.append('<input type="text" id="testmask" />');
+		var testmask = document.getElementById("testmask");
+		Inputmask("dd/mm/yyyy", {
+			yearrange: {
+				minyear: 1900,
+				maxyear: 2016
+			}
+		}).mask(testmask);
+
+		testmask.focus();
+
+		$("#testmask").Type("23373");
+		assert.equal(testmask.value, "23/03/1973", "Result " + testmask.value);
+	});
+
+	qunit.test("inputmask(\"dd/mm/yyyy\", { yearrange: { minyear: 1900, maxyear: 2017 } })", function(assert) {
+		var $fixture = $("#qunit-fixture");
+		$fixture.append('<input type="text" id="testmask" />');
+		var testmask = document.getElementById("testmask");
+		Inputmask("dd/mm/yyyy", {
+			yearrange: {
+				minyear: 1900,
+				maxyear: 2017
+			}
+		}).mask(testmask);
+
+		testmask.focus();
+
+		$("#testmask").Type("23373");
+		assert.equal(testmask.value, "23/03/1973", "Result " + testmask.value);
+	});
+
+	qunit.test("inputmask(\"dd/mm/yyyy\", { yearrange: { minyear: 1900, maxyear: 2018 } })", function(assert) {
+			var $fixture = $("#qunit-fixture");
+			$fixture.append('<input type="text" id="testmask" />');
+			var testmask = document.getElementById("testmask");
+			Inputmask("dd/mm/yyyy", {
+				yearrange: {
+					minyear: 1900,
+					maxyear: 2018
+				}
+			}).mask(testmask);
+
+			testmask.focus();
+
+			$("#testmask").Type("23373");
+			assert.equal(testmask.value, "23/03/1973", "Result " + testmask.value);
+	});
+
+	qunit.test("inputmask(\"dd/mm/yyyy\", { yearrange: { minyear: 1900, maxyear: 2019 } })", function(assert) {
+			var $fixture = $("#qunit-fixture");
+			$fixture.append('<input type="text" id="testmask" />');
+			var testmask = document.getElementById("testmask");
+			Inputmask("dd/mm/yyyy", {
+				yearrange: {
+					minyear: 1900,
+					maxyear: 2019
+				}
+			}).mask(testmask);
+
+			testmask.focus();
+
+			$("#testmask").Type("23373");
+			assert.equal(testmask.value, "23/03/1973", "Result " + testmask.value);
+	});
+
+	qunit.test("inputmask(\"dd/mm/yyyy\", { yearrange: { minyear: 1900, maxyear: 2018 } }) -- 2012", function(assert) {
+			var $fixture = $("#qunit-fixture");
+			$fixture.append('<input type="text" id="testmask" />');
+			var testmask = document.getElementById("testmask");
+			Inputmask("dd/mm/yyyy", {
+				yearrange: {
+					minyear: 1900,
+					maxyear: 2018
+				}
+			}).mask(testmask);
+
+			testmask.focus();
+
+			$("#testmask").Type("23312");
+			assert.equal(testmask.value, "23/03/2012", "Result " + testmask.value);
+	});
 });


### PR DESCRIPTION
`minyear` in 19xx and `maxyear` in 20xx, and `maxyear` greater than or equal to the current year, then it will only accept two digit years less than the current year.

Prior to this PR:

| minyear | maxyear | keyed | expected | actual |
| --- | --- | --- | --- | --- |
| 1900 | 2016 | 13 | 2013 | 2013 |
| 1900 | 2016 | 17 | 1917 | ---- |
