### PR TITLE
leadingZeroHandler FIX

### DIFF
--- a/dist/inputmask/inputmask.numeric.extensions.js
+++ b/dist/inputmask/inputmask.numeric.extensions.js
@@ -205,7 +205,7 @@
             leadingZeroHandler: function(chrs, maskset, pos, strict, opts, isSelection) {
                 if (!strict) if (opts.numericInput === !0) {
                     var buffer = maskset.buffer.slice("").reverse(), char = buffer[opts.prefix.length];
-                    if ("0" === char) return {
+                    if ("0" === char && 0 === pos) return {
                         pos: pos,
                         remove: buffer.length - opts.prefix.length - 1
                     };


### PR DESCRIPTION
Fix the problem on set "20.00" (or X0.00 : X is the number!) to not remove the "0". 

Value (set in `value` or `.val()`):
20.00 | 010.00

Before this edit:
2.00   | 1.00

Now:
20.00 | 10.00
