### PR TITLE
Fix formatting and enable value patch for IE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [UNRELEASED]
 
 ### Updates
+- patchValueProperty - enable native value property patch on IE8/IE9
 - speedup insert and delete from characters
 - adding extra options through option method => auto apply the mask + add noremask option
 

--- a/js/inputmask.js
+++ b/js/inputmask.js
@@ -2076,6 +2076,14 @@
 
 			if (!npt.inputmask.__valueGet) {
 				if (Object.getOwnPropertyDescriptor) {
+					if (typeof Object.getPrototypeOf !== "function") {
+						Object.getPrototypeOf = typeof "test".__proto__ === "object" ? function (object) {
+							return object.__proto__;
+						} : function (object) {
+							return object.constructor.prototype;
+						};
+					}
+
 					var valueProperty = Object.getPrototypeOf ? Object.getOwnPropertyDescriptor(Object.getPrototypeOf(npt), "value") : undefined;
 					if (valueProperty && valueProperty.get && valueProperty.set) {
 						valueGet = valueProperty.get;


### PR DESCRIPTION
Commit https://github.com/RobinHerbots/jquery.inputmask/commit/1934c1766df25cbc5c3dc92f2cc14e6eb36a6be8 has broken formatting so I applied the same patch to the previous commit.
