### PR TITLE
YUI Compressor keyword error

### DIFF
--- a/dist/inputmask/inputmask.numeric.extensions.js
+++ b/dist/inputmask/inputmask.numeric.extensions.js
@@ -209,8 +209,8 @@
             },
             leadingZeroHandler: function(chrs, maskset, pos, strict, opts, isSelection) {
                 if (!strict) if (opts.numericInput === !0) {
-                    var buffer = maskset.buffer.slice("").reverse(), char = buffer[opts.prefix.length];
-                    if ("0" === char && void 0 === maskset.validPositions[pos - 1]) return {
+                    var buffer = maskset.buffer.slice("").reverse(), bufferChar = buffer[opts.prefix.length];
+                    if ("0" === bufferChar && void 0 === maskset.validPositions[pos - 1]) return {
                         pos: pos,
                         remove: buffer.length - opts.prefix.length - 1
                     };

--- a/dist/jquery.inputmask.bundle.js
+++ b/dist/jquery.inputmask.bundle.js
@@ -2303,8 +2303,8 @@
             },
             leadingZeroHandler: function(chrs, maskset, pos, strict, opts, isSelection) {
                 if (!strict) if (opts.numericInput === !0) {
-                    var buffer = maskset.buffer.slice("").reverse(), char = buffer[opts.prefix.length];
-                    if ("0" === char && void 0 === maskset.validPositions[pos - 1]) return {
+                    var buffer = maskset.buffer.slice("").reverse(), bufferChar = buffer[opts.prefix.length];
+                    if ("0" === bufferChar && void 0 === maskset.validPositions[pos - 1]) return {
                         pos: pos,
                         remove: buffer.length - opts.prefix.length - 1
                     };

--- a/js/inputmask.numeric.extensions.js
+++ b/js/inputmask.numeric.extensions.js
@@ -411,8 +411,8 @@
 				if (!strict) {
 					if (opts.numericInput === true) {
 						var buffer = maskset.buffer.slice("").reverse();
-						var char = buffer[opts.prefix.length];
-						if (char === "0" && maskset.validPositions[pos - 1] === undefined) {
+						var bufferChar = buffer[opts.prefix.length];
+						if (bufferChar === "0" && maskset.validPositions[pos - 1] === undefined) {
 							return {
 								"pos": pos,
 								"remove": buffer.length - opts.prefix.length - 1


### PR DESCRIPTION
This commit should fix #1242 in which YUI Compressor throws an error for naming a variable `char`.
