### PR TITLE
Add missing .js extensions to bower main files

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,14 +2,14 @@
   "name": "jquery.inputmask",
   "version": "3.3.5-33",
   "main": [
-	  "./dist/inputmask/inputmask.dependencyLib",
-	  "./dist/inputmask/inputmask",
-	  "./dist/inputmask/inputmask.extensions",
-	  "./dist/inputmask/inputmask.date.extensions",
-	  "./dist/inputmask/inputmask.numeric.extensions",
-	  "./dist/inputmask/inputmask.phone.extensions",
-	  "./dist/inputmask/inputmask.regex.extensions",
-	  "./dist/inputmask/jquery.inputmask"
+	  "./dist/inputmask/inputmask.dependencyLib.js",
+	  "./dist/inputmask/inputmask.js",
+	  "./dist/inputmask/inputmask.extensions.js",
+	  "./dist/inputmask/inputmask.date.extensions.js",
+	  "./dist/inputmask/inputmask.numeric.extensions.js",
+	  "./dist/inputmask/inputmask.phone.extensions.js",
+	  "./dist/inputmask/inputmask.regex.extensions.js",
+	  "./dist/inputmask/jquery.inputmask.js"
   ],
   "keywords": ["jquery", "plugins", "input", "form", "inputmask", "mask"],
   "description": "jquery.inputmask is a jquery plugin which create an input mask.",


### PR DESCRIPTION
Bower's main files somehow lost their .js extension. This caused problems with my gulp build process.