### PR TITLE
fix use of hexadecimal symbol in documentation

### DIFF
--- a/README_other.md
+++ b/README_other.md
@@ -2,7 +2,7 @@
 ## Definitions
 - A   :     alphabetical uppercasing
 - &   :     alfanumeric uppercasing
-- #  :     hexadecimal
+- \#  :     hexadecimal
 
 ## Aliases
 ### URL


### PR DESCRIPTION
the `#` used in the doc was interpreted as a markdown title