### PR TITLE
Element keeps the focus to itself in ie11

### DIFF
--- a/js/inputmask.js
+++ b/js/inputmask.js
@@ -2542,8 +2542,10 @@
 
                         input.inputmask.caretPos = {begin: begin, end: end}; //track caret internally
                         if ("selectionStart" in input) {
-                            input.selectionStart = begin;
-                            input.selectionEnd = end;
+                            if (input === document.activeElement) {
+                              input.selectionStart = begin;
+                              input.selectionEnd = end;
+                            }
                         } else if (window.getSelection) {
                             range = document.createRange();
                             if (input.firstChild === undefined || input.firstChild === null) {


### PR DESCRIPTION
Fixed issue where in ie11 when setting a value to the input field this was taking focus, this was addressed by updating the selection end and start only when the element is the current element in focus.