### PR TITLE
Document bug with disabled inputs caused by Firefox 64 and older

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ You can choose between:
 - inputmask.dependencyLib.jqlite
 - .... (others are welcome)
 
+**Warning**: Using any dependency library that relies on the `CustomEvent` object or the `document.createEvent` DOM API will have issues with updating values in disabled inputs, in Firefox 64 and older. This is caused by [an old Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=329509), that has been fixed in Firefox 65. Currently, this means that `inputmask.dependencyLib` and `inputmask.dependencyLib.jqlite` are affected by this bug.
+
 ### Classic web with <script\> tag
 Include the js-files which you can find in the `dist` folder.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ You can choose between:
 - inputmask.dependencyLib.jqlite
 - .... (others are welcome)
 
-**Warning**: Using any dependency library that relies on the `CustomEvent` object or the `document.createEvent` DOM API will have issues with updating values in disabled inputs, in Firefox 64 and older. This is caused by [an old Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=329509), that has been fixed in Firefox 65. Currently, this means that `inputmask.dependencyLib` and `inputmask.dependencyLib.jqlite` are affected by this bug.
+**Warning**: Using any dependency library that relies on the `CustomEvent` object or the `document.createEvent` DOM API will have issues with updating values in disabled inputs, in Firefox 64 and older. This is caused by [an old Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=329509), that has been fixed in Firefox 65. Currently, this means that `inputmask.dependencyLib` and `inputmask.dependencyLib.jqlite` are affected by this bug. See #2045 for more details.
 
 ### Classic web with <script\> tag
 Include the js-files which you can find in the `dist` folder.


### PR DESCRIPTION
When using dependency libraries that depend on native events, in Firefox 64 and older, the input getter will not provide the correct value if it was set while the input is disabled, because the setter cannot trigger the event on the input ([see this Firefox bug report](https://bugzilla.mozilla.org/show_bug.cgi?id=329509)). This can prove problematic when updating disabled fields by tying forms with models and the model load is delayed, or maybe the input is updated via user actions in other fields, etc.

[See this JSFiddle in Firefox 64 or older to understand the bug.](https://jsfiddle.net/o76xsg1m/1/)

Because this Firefox bug will be fixed in v65, which should land in January 2019, I don't think a fix is required. However, this issue should definitely be documented, because we spent quite a few hours debugging it, as it caused potential data loss in certain scenarios in our app.

