### PR TITLE
Fix issues with Chromium

### DIFF
--- a/dist/inputmask.js
+++ b/dist/inputmask.js
@@ -3241,9 +3241,8 @@ function maskScope(actionObj, maskset, opts) {
         }; //track caret internally
 
         if (input === document.activeElement) {
-          if ("selectionStart" in input) {
-            input.selectionStart = begin;
-            input.selectionEnd = end;
+          if ("setSelectionRange" in input) {
+            input.setSelectionRange(begin, end);
           } else if (window.getSelection) {
             range = document.createRange();
 
@@ -3273,7 +3272,7 @@ function maskScope(actionObj, maskset, opts) {
         }
       }
     } else {
-      if ("selectionStart" in input) {
+      if ("selectionStart" in input && "selectionEnd" in input) {
         begin = input.selectionStart;
         end = input.selectionEnd;
       } else if (window.getSelection) {

--- a/dist/inputmask.min.js
+++ b/dist/inputmask.min.js
@@ -3241,9 +3241,8 @@ function maskScope(actionObj, maskset, opts) {
         }; //track caret internally
 
         if (input === document.activeElement) {
-          if ("selectionStart" in input) {
-            input.selectionStart = begin;
-            input.selectionEnd = end;
+          if ("setSelectionRange" in input) {
+            input.setSelectionRange(begin, end);
           } else if (window.getSelection) {
             range = document.createRange();
 
@@ -3273,7 +3272,7 @@ function maskScope(actionObj, maskset, opts) {
         }
       }
     } else {
-      if ("selectionStart" in input) {
+      if ("selectionStart" in input && "selectionEnd" in input) {
         begin = input.selectionStart;
         end = input.selectionEnd;
       } else if (window.getSelection) {

--- a/dist/jquery.inputmask.js
+++ b/dist/jquery.inputmask.js
@@ -3255,9 +3255,8 @@ function maskScope(actionObj, maskset, opts) {
         }; //track caret internally
 
         if (input === document.activeElement) {
-          if ("selectionStart" in input) {
-            input.selectionStart = begin;
-            input.selectionEnd = end;
+          if ("setSelectionRange" in input) {
+            input.setSelectionRange(begin, end);
           } else if (window.getSelection) {
             range = document.createRange();
 
@@ -3287,7 +3286,7 @@ function maskScope(actionObj, maskset, opts) {
         }
       }
     } else {
-      if ("selectionStart" in input) {
+      if ("selectionStart" in input && "selectionEnd" in input) {
         begin = input.selectionStart;
         end = input.selectionEnd;
       } else if (window.getSelection) {

--- a/dist/jquery.inputmask.min.js
+++ b/dist/jquery.inputmask.min.js
@@ -3255,9 +3255,8 @@ function maskScope(actionObj, maskset, opts) {
         }; //track caret internally
 
         if (input === document.activeElement) {
-          if ("selectionStart" in input) {
-            input.selectionStart = begin;
-            input.selectionEnd = end;
+          if ("setSelectionRange" in input) {
+            input.setSelectionRange(begin, end);
           } else if (window.getSelection) {
             range = document.createRange();
 
@@ -3287,7 +3286,7 @@ function maskScope(actionObj, maskset, opts) {
         }
       }
     } else {
-      if ("selectionStart" in input) {
+      if ("selectionStart" in input && "selectionEnd" in input) {
         begin = input.selectionStart;
         end = input.selectionEnd;
       } else if (window.getSelection) {

--- a/lib/inputmask.js
+++ b/lib/inputmask.js
@@ -2584,9 +2584,8 @@ function maskScope(actionObj, maskset, opts) {
 
                 input.inputmask.caretPos = {begin: begin, end: end}; //track caret internally
                 if (input === document.activeElement) {
-                    if ("selectionStart" in input) {
-                        input.selectionStart = begin;
-                        input.selectionEnd = end;
+                    if ("setSelectionRange" in input) {
+                        input.setSelectionRange(begin, end);
                     } else if (window.getSelection) {
                         range = document.createRange();
                         if (input.firstChild === undefined || input.firstChild === null) {
@@ -2615,7 +2614,7 @@ function maskScope(actionObj, maskset, opts) {
                 }
             }
         } else {
-            if ("selectionStart" in input) {
+            if ("selectionStart" in input && "selectionEnd" in input) {
                 begin = input.selectionStart;
                 end = input.selectionEnd;
             } else if (window.getSelection) {

--- a/qunit/simulator.js
+++ b/qunit/simulator.js
@@ -10,8 +10,7 @@ export default function ($, Inputmask) {
             // }
 
             if (input.setSelectionRange) {
-                input.selectionStart = begin;
-                input.selectionEnd = end;
+                input.setSelectionRange(begin, end);
             } else if (window.getSelection) {
                 range = document.createRange();
                 if (input.firstChild === undefined) {
@@ -34,7 +33,7 @@ export default function ($, Inputmask) {
 
             }
         } else {
-            if (input.setSelectionRange) {
+            if ("selectionStart" in input && "selectionEnd" in input) {
                 begin = input.selectionStart;
                 end = input.selectionEnd;
             } else if (window.getSelection) {


### PR DESCRIPTION
We are running a test automation infrastructure based on Linux, Chromium and Chromedriver.

After introducing this script into one of our projects, our test infrastructure wouldn't run tests affected by this script any more. After spending hours of debugging, we found out that Chromium (57.0.2987.98 to latest 71 build) all failed and crashed (no further output in the Chromium logs) because `input.selectionStart` was called. Our problems have been fixed, by using the `setSelectionRange` method over `selectionStart` & `selectionEnd`. https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/setSelectionRange

This PR fixes our problems, and we would like to contribute to the project, by contributing it back to the source.
Let us know how we want to proceed, and what we might do, to get this merged.

Best Regards
Sebastian