### PR TITLE
Fix memory leak by moving the "positionColorMask" declaration outside of function scope

### DIFF
--- a/js/inputmask.js
+++ b/js/inputmask.js
@@ -633,6 +633,9 @@ Inputmask.prototype = {
         }
         // console.log(JSON.stringify(maskTokens));
         return maskTokens;
+    },
+    positionColorMask: function (input, template) {
+        input.style.left = template.offsetLeft + "px";
     }
 };
 
@@ -2807,10 +2810,6 @@ function maskScope(actionObj, maskset, opts) {
             caret(input, findCaretPos(e.clientX));
             return EventHandlers.clickEvent.call(input, [e]);
         });
-    }
-
-    Inputmask.prototype.positionColorMask = function (input, template) {
-        input.style.left = template.offsetLeft + "px";
     }
 
     function renderColorMask(input, caretPos, clear) {


### PR DESCRIPTION
## Purpose
During a performance issues investigation in our app, which uses Inputmask heavily, we found out that an Inputmask instance was leaked, further leaking various objects referenced in that scope. This created a large memory leak after prolonged usage, as the app is a SPA, so the users rarely refresh the page and we have tens or hundreds of inputs with input masks on some pages.

## Approach
The leaked scope was that of `maskScope`, which attaches the `positionColorMask` method on the Inputmask prototype. I'm not yet sure why the scope is leaked, since the `positionColorMask` function does not access any variable outside its own scope, but it definitely was leaked.

The `maskScope` function scope was retained on the prototype, which was retained in the global module registry (we use Babel and imports in our app), which is ultimately set on window, thus retaining the last `maskScope` through this chain.

I could not reproduce this outside our app in a JSFiddle, which is probably because we have the import usage and the module registry, which was not present in JSFiddle. However, with the fix in this PR we noticed a visible reduction in memory usage after instantiating / destroying multiple input masks. 

Finally, even without a reproduction, it does not make sense for that method to be declared inside `maskScope`, especially because it does not use anything from the scope. It might have made sense when it was first implemented, but right now the prototype declaration is the right place for declaring this method.