### PR TITLE
#2182: Preventing multiple redundant keypressEvent from being trigger…

### DIFF
--- a/dist/jquery.inputmask.js
+++ b/dist/jquery.inputmask.js
@@ -1370,7 +1370,7 @@
                             }), 0 < entries.length) document.activeElement !== input && (input.focus(), caret(input, selection)), 
                             $.each(entries.split(""), function(ndx, entry) {
                                 var keypress = new $.Event("keypress");
-                                keypress.which = entry.charCodeAt(0), ignorable = !1, EventHandlers.keypressEvent.call(input, keypress);
+                                keypress.which = entry.charCodeAt(0), ignorable = !1, (!e.originalEvent || e.originalEvent.inputType !== "insertCompositionText") && EventHandlers.keypressEvent.call(input, keypress);
                             }); else {
                                 selection.begin === selection.end - 1 && (selection.begin = seekPrevious(selection.begin + 1), 
                                 selection.begin === selection.end - 1 ? caret(input, selection.begin) : caret(input, selection.begin, selection.end));


### PR DESCRIPTION
#2182: Preventing multiple redundant keypressEvent from being triggered on Chrome for typing-in-progress input from Sogou-like IME

Demo of the fix:
![Chrome_Foreign_IME_Issue_after](https://user-images.githubusercontent.com/2230873/64402807-19c1de00-d044-11e9-9680-1c916735f6f3.gif)

jsFiddle: https://jsfiddle.net/yunyunzai/bt4ds02f/


