### PR TITLE
add test for numeric input, when positionCaretOnClick: select and end…

### DIFF
--- a/qunit/tests_numeric.js
+++ b/qunit/tests_numeric.js
@@ -2145,4 +2145,26 @@ export default function (qunit, Inputmask) {
 			done();
 		},0);
 	});
+
+	qunit.test("test add new number at the end with positionCaretOnClick: select, using END key", function (assert) {
+		var done = assert.async(),
+			$fixture = $("#qunit-fixture");
+		$fixture.append('<input type="text" id="testmask" value="123.45" />');
+		var testmask = document.getElementById("testmask");
+		Inputmask("decimal", {
+			positionCaretOnClick: 'select',
+			radixFocus: true,
+			digitsOptional: false,
+			digits: 2,
+			_radixDance: true,
+			numericInput: true,
+		}).mask(testmask);
+		testmask.focus();
+		$("#testmask").SendKey(keyCode.END);
+		$(testmask).Type("6");
+		setTimeout(function () {
+			assert.equal(testmask.value, "1234.56", "Result " + testmask.value);
+			done();
+		}, 5);
+	});
 };


### PR DESCRIPTION
add test for numeric input, when positionCaretOnClick: select and END key is pressed should add number at the end when any number is pressed.

i tried to add a test to RIGHT key, but in the test the cursor moves one character right, in browser manual tests in the browser works as expected(go to end of the selection).