### PR TITLE
fix async handling of focus when the mask is destroyed just after it was created

### DIFF
--- a/lib/maskScope.js
+++ b/lib/maskScope.js
@@ -1304,6 +1304,10 @@ module.exports = function maskScope(actionObj, maskset, opts) {
 							}
 							args = arguments;
 							setTimeout(function () { //needed for Chrome ~ initial selection clears after the clickevent
+								if (!input.inputmask) {
+									// `inputmask.remove()` was called before this callback
+									return;
+								}
 								eventHandler.apply(that, args);
 							}, 0);
 							return false;


### PR DESCRIPTION
Otherwise an error can be thrown: `Cannot read property '_valueGet' of undefined`

This happens for me in tests that involve this component. Sometimes the whole test is run synchronously, which means both the construction and destroying of an Inputmask instance happen in the same turn of the event loop, and when the callback of `setTimeout` is run, the instance is already destroyed.