### PR TITLE
fix issue with numeric mask when setting empty value

### DIFF
--- a/js/inputmask.numeric.extensions.js
+++ b/js/inputmask.numeric.extensions.js
@@ -252,6 +252,10 @@
                     processValue = processValue.replace(/^0/g, "");
                 }
 
+                if (processValue === opts.radixPoint) {
+                    processValue = "";
+                }
+
                 if (processValue.charAt(0) === opts.radixPoint && opts.radixPoint !== "" && opts.numericInput !== true) {
                     processValue = "0" + processValue;
                 }

--- a/qunit/tests_numeric.js
+++ b/qunit/tests_numeric.js
@@ -2114,4 +2114,19 @@ export default function (qunit, Inputmask) {
 
         assert.equal(testmask.value, "0,001", "Result " + testmask.value);
     });
+
+    qunit.test("numeric clear value - honboubao", function (assert) {
+        var $fixture = $("#qunit-fixture");
+        $fixture.append('<input type="text" id="testmask"/>');
+        var testmask = document.getElementById("testmask");
+        Inputmask("numeric", {
+            radixPoint: ",",
+            placeholder: "_",
+            digits: 2,
+            digitsOptional: false
+        }).mask(testmask);
+        testmask.value = "";
+
+        assert.equal(testmask.value, "", "Result \"" + testmask.value + "\"");
+    });
 };


### PR DESCRIPTION
I have found that using a numeric mask with any placeholder other than a digit character and non-optional fractional part will result in the input not accepting an empty string as value anymore since an empty string will be processed into a numeric zero value, e.g. "0,00".

Here is an example of the issue in the 4.x branch: https://jsfiddle.net/z2pufn7h/2/

This issue doesn't exist on the 5.x branch, as can be seen in this example: https://jsfiddle.net/cubn04py/2/


This pull request fixes this issue, as can be tested here: https://jsfiddle.net/7kdejouz/