### PR TITLE
Update README_numeric.md

### DIFF
--- a/README_numeric.md
+++ b/README_numeric.md
@@ -97,6 +97,9 @@ Other examples:
 - Math.floor 
 - fn(x) { /* do your own rounding logic */ return x; }
 
+### inputmode
+Default: "decimal"
+
 ### shortcuts: 
 Default: {k: "000", m: "000000"}
 
@@ -104,11 +107,6 @@ Define shortcuts.
 This will allow typing 1k => 1000, 2m => 2000000
  
 To disable just pass shortcuts: null as option
-
-### inputType
-Indicates whether the value passed for initialization is text or a number
-
-Default: "text"
 
 ### Setting initial values
 


### PR DESCRIPTION
Replace repeated `inputType` with missing `inputmode` option.