### PR TITLE
Fix cut and paste events

### DIFF
--- a/lib/eventhandlers.js
+++ b/lib/eventhandlers.js
@@ -185,15 +185,16 @@ var EventHandlers = {
 		if (typeof opts.onBeforePaste === "function") {
 			pasteValue = opts.onBeforePaste.call(inputmask, inputValue, opts);
 			if (pasteValue === false) {
-				return e.preventDefault();
+				return false;
 			}
 			if (!pasteValue) {
 				pasteValue = inputValue;
 			}
 		}
 		checkVal(input, true, false, pasteValue.toString().split(""), e);
-
-		return e.preventDefault();
+		
+		// e.preventDefault() is invoked on upper level
+		return false;
 	},
 	inputFallBackEvent: function (e) { //fallback when keypress is not triggered
 		const inputmask = this.inputmask, opts = inputmask.opts, $ = inputmask.dependencyLib;
@@ -406,9 +407,8 @@ var EventHandlers = {
 		//correct clipboardData
 		var clipboardData = window.clipboardData || e.clipboardData,
 			clipData = inputmask.isRTL ? getBuffer.call(inputmask).slice(pos.end, pos.begin) : getBuffer.call(inputmask).slice(pos.begin, pos.end);
-		clipboardData.setData("text", inputmask.isRTL ? clipData.reverse().join("") : clipData.join(""));
-		if (document.execCommand) document.execCommand("copy"); // copy selected content to system clipbaord
-
+		clipboardData.setData("text", inputmask.isRTL ? clipData.reverse().join("") : clipData.join("")); // copy selected data to a clipboard
+		
 		handleRemove.call(inputmask, input, keyCode.DELETE, pos);
 		writeBuffer(input, getBuffer.call(inputmask), maskset.p, e, inputmask.undoValue !== inputmask._valueGet(true));
 	}

--- a/lib/eventhandlers.js
+++ b/lib/eventhandlers.js
@@ -192,8 +192,8 @@ var EventHandlers = {
 			}
 		}
 		checkVal(input, true, false, pasteValue.toString().split(""), e);
+		inputmask.$el.trigger("input");
 		
-		// e.preventDefault() is invoked on upper level
 		return false;
 	},
 	inputFallBackEvent: function (e) { //fallback when keypress is not triggered
@@ -406,8 +406,10 @@ var EventHandlers = {
 
 		//correct clipboardData
 		var clipboardData = window.clipboardData || e.clipboardData,
-			clipData = inputmask.isRTL ? getBuffer.call(inputmask).slice(pos.end, pos.begin) : getBuffer.call(inputmask).slice(pos.begin, pos.end);
-		clipboardData.setData("text", inputmask.isRTL ? clipData.reverse().join("") : clipData.join("")); // copy selected data to a clipboard
+			clipData = inputmask.isRTL ? getBuffer.call(inputmask).slice(pos.end, pos.begin) : getBuffer.call(inputmask).slice(pos.begin, pos.end),
+		    	clipDataText = inputmask.isRTL ? clipData.reverse().join("") : clipData.join("");
+		clipboardData.setData("text", clipDataText); // copy selected data to a clipboard
+		if (window.navigator.clipboard) window.navigator.clipboard.writeText(clipDataText);
 		
 		handleRemove.call(inputmask, input, keyCode.DELETE, pos);
 		writeBuffer(input, getBuffer.call(inputmask), maskset.p, e, inputmask.undoValue !== inputmask._valueGet(true));


### PR DESCRIPTION
CUT: remove deprecated execCommand (https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand). Keep  recommended and new API (navigator.clipboard)
PASTE: remove e.preventDefault() from pasteEvent, as it is invoked in the upper level method. Invoke `input` event.