### PR TITLE
Update tests_base.js

### DIFF
--- a/qunit/tests_base.js
+++ b/qunit/tests_base.js
@@ -25,11 +25,11 @@ export default function (qunit, Inputmask) {
 
 		Inputmask({
 			mask: "99-99-99",
-			clearMaskOnLostFocus: false
+			clearMaskOnLostFocus: true
 		}).mask(testmask);
 		testmask.blur();
 		setTimeout(function () {
-			assert.equal(testmask.value, "", "Result " + testmask.value);
+			assert.equal(testmask.inputmask._valueGet(), "", "Result " + testmask.inputmask._valueGet());
 			done();
 		}, 0);
 	});


### PR DESCRIPTION
testmask.value is independent of the clearMaskOnLostFocus property. Based on the previous test, this should be exactly the mask value when clearMaskOnLostFocus: true.