### PR TITLE
Add exports field

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "5.0.8-beta.73",
   "description": "Inputmask is a javascript library which creates an input mask.  Inputmask can run against vanilla javascript, jQuery and jqlite.",
   "main": "dist/inputmask.js",
+  "exports": {
+    ".": "./dist/inputmask.js",
+    "./dist/*.js": "./dist/*.js",
+  },
   "files": [
     "bundle.js",
     "dist/",


### PR DESCRIPTION
This allows CDNs like JSPM to pick up on all dist files

NOTE: Someone should review [this](https://nodejs.org/api/packages.html#package-entry-points) before merging, because it's possible this is introducing a breaking change. I'll let a maintainer judge if that's the case, and decide how to proceed.