### PR TITLE
fix: Inputmask works weird under ShadowDOM

### DIFF
--- a/lib/eventhandlers.js
+++ b/lib/eventhandlers.js
@@ -296,7 +296,7 @@ var EventHandlers = {
 
         if (buffer !== inputValue) {
             changes = analyseChanges(inputValue, buffer, caretPos);
-            if ((input.inputmask.shadowRoot || input.ownerDocument).activeElement !== input) {
+            if ((input.inputmask.shadowRoot || input.getRootNode()).activeElement !== input) {
                 input.focus();
             }
             writeBuffer(input, getBuffer.call(inputmask));
@@ -380,7 +380,7 @@ var EventHandlers = {
 
         var input = this;
         inputmask.mouseEnter = false;
-        if (opts.clearMaskOnLostFocus && (input.inputmask.shadowRoot || input.ownerDocument).activeElement !== input) {
+        if (opts.clearMaskOnLostFocus && (input.inputmask.shadowRoot || input.getRootNode()).activeElement !== input) {
             HandleNativePlaceholder(input, inputmask.originalPlaceholder);
         }
     },
@@ -389,7 +389,7 @@ var EventHandlers = {
         inputmask.clicked++;
 
         var input = this;
-        if ((input.inputmask.shadowRoot || input.ownerDocument).activeElement === input) {
+        if ((input.inputmask.shadowRoot || input.getRootNode()).activeElement === input) {
             var newCaretPosition = determineNewCaretPosition.call(inputmask, caret.call(inputmask, input), tabbed);
             if (newCaretPosition !== undefined) {
                 caret.call(inputmask, input, newCaretPosition);
@@ -465,7 +465,7 @@ var EventHandlers = {
 
         var input = this;
         inputmask.mouseEnter = true;
-        if ((input.inputmask.shadowRoot || input.ownerDocument).activeElement !== input) {
+        if ((input.inputmask.shadowRoot || input.getRootNode()).activeElement !== input) {
             var bufferTemplate = (inputmask.isRTL ? getBufferTemplate.call(inputmask).slice().reverse() : getBufferTemplate.call(inputmask)).join("");
             if (showMaskOnHover) {
                 HandleNativePlaceholder(input, bufferTemplate);

--- a/lib/mask.js
+++ b/lib/mask.js
@@ -60,7 +60,7 @@ function mask() {
                     return this.inputmask.opts.autoUnmask ?
                         this.inputmask.unmaskedvalue() :
                         (getLastValidPosition.call(inputmask) !== -1 || opts.nullable !== true ?
-                            (((this.inputmask.shadowRoot || this.ownerDocument).activeElement) === this && opts.clearMaskOnLostFocus ?
+                            (((this.inputmask.shadowRoot || this.getRootNode()).activeElement) === this && opts.clearMaskOnLostFocus ?
                                 (inputmask.isRTL ? clearOptionalTail.call(inputmask, getBuffer.call(inputmask).slice()).reverse() : clearOptionalTail.call(inputmask, getBuffer.call(inputmask).slice())).join("") :
                                 valueGet.call(this)) :
                             "");
@@ -218,7 +218,7 @@ function mask() {
         //apply mask
         getBufferTemplate.call(inputmask).join(""); //initialize the buffer and getmasklength
         inputmask.undoValue = inputmask._valueGet(true);
-        var activeElement = (el.inputmask.shadowRoot || el.ownerDocument).activeElement;
+        var activeElement = (el.inputmask.shadowRoot || el.getRootNode()).activeElement;
         if (el.inputmask._valueGet(true) !== "" || opts.clearMaskOnLostFocus === false || activeElement === el) {
             applyInputValue(el, el.inputmask._valueGet(true), opts);
             var buffer = getBuffer.call(inputmask).slice();

--- a/lib/positioning.js
+++ b/lib/positioning.js
@@ -46,7 +46,7 @@ function caret(input, begin, end, notranslate, isDelete) {
             // 	return;
             // }
 
-            var scrollCalc = parseInt(((input.ownerDocument.defaultView || window).getComputedStyle ? (input.ownerDocument.defaultView || window).getComputedStyle(input, null) : input.currentStyle).fontSize) * end;
+            var scrollCalc = parseInt(((input.getRootNode().defaultView || window).getComputedStyle ? (input.getRootNode().defaultView || window).getComputedStyle(input, null) : input.currentStyle).fontSize) * end;
             input.scrollLeft = scrollCalc > input.scrollWidth ? scrollCalc : 0;
             input.inputmask.caretPos = {begin: begin, end: end}; //track caret internally
             if (opts.insertModeVisual && opts.insertMode === false && begin === end) {
@@ -54,7 +54,7 @@ function caret(input, begin, end, notranslate, isDelete) {
                     end++; //set visualization for insert/overwrite mode
                 }
             }
-            if (input === (input.inputmask.shadowRoot || input.ownerDocument).activeElement) {
+            if (input === (input.inputmask.shadowRoot || input.getRootNode()).activeElement) {
                 if ("setSelectionRange" in input) {
                     input.setSelectionRange(begin, end);
                 } else if (window.getSelection) {


### PR DESCRIPTION
I found input mask works weird under ShadowDOM. 
I think Node.ownerDocument API returns only Document, not ShadowDOM's root Document.
Therefore, I change from ownerDocument to [getRootNode()](https://developer.mozilla.org/en-US/docs/Web/API/Node/getRootNode) API . 
This API returns not only the root node(Document) but also root node of Shadow DOM.
I tested with build codes in my cases, and it works fine.
