### PR TITLE
Fix Chinese IME input duplication on Safari

### DIFF
--- a/inputmask-pages/src/assets/Changelog.md
+++ b/inputmask-pages/src/assets/Changelog.md
@@ -21,6 +21,7 @@
 
 ### Fixed
 
+- Chinese IME input causes character duplication on Safari
 - Turkish Locale for Uppercase, Lowercase and Title #2853
 - Change event fired even no value entered in decimal masked input #2852
 - Numeric field value cannot be reset to empty from outside of input. #2829

--- a/lib/eventhandlers.js
+++ b/lib/eventhandlers.js
@@ -158,6 +158,15 @@ const EventHandlers = {
 
     inputmask.isComposing = c == keys.Process || c == keys.Unidentified;
 
+    // Prevent duplicate input processing between keyEvent and inputFallBackEvent
+    // This fixes Chinese IME duplication issue on Safari where both events fire for the same input
+    const now = Date.now();
+    if (inputmask.lastInputProcessed && 
+        (now - inputmask.lastInputProcessed.time) < 10 && 
+        inputmask.lastInputProcessed.data === c) {
+      return false;
+    }
+
     inputmask.ignorable = c === undefined || c.length > 1;
     return EventHandlers.keypressEvent.call(
       this,
@@ -327,6 +336,15 @@ const EventHandlers = {
       $ = inputmask.dependencyLib;
 
     // console.log(e.inputType);
+
+    // Prevent duplicate input processing between keyEvent and inputFallBackEvent
+    // This fixes Chinese IME duplication issue on Safari where both events fire for the same input
+    const now = Date.now();
+    if (inputmask.lastInputProcessed && 
+        (now - inputmask.lastInputProcessed.time) < 10 && 
+        inputmask.lastInputProcessed.data === e.data) {
+      return;
+    }
 
     function analyseChanges(inputValue, buffer, caretPos) {
       let frontPart = inputValue.substr(0, caretPos.begin).split(""),
@@ -517,6 +535,13 @@ const EventHandlers = {
           caret.call(inputmask, input, caretPos.begin, caretPos.end, true);
           break;
       }
+
+      // Mark input as processed to prevent duplicate handling by keyEvent
+      // This fixes Chinese IME duplication issue on Safari
+      inputmask.lastInputProcessed = {
+        time: Date.now(),
+        data: e.data
+      };
 
       e.preventDefault();
     }

--- a/lib/inputmask.js
+++ b/lib/inputmask.js
@@ -58,6 +58,7 @@ function Inputmask(alias, options, internal) {
   this.clicked = 0;
   this.originalPlaceholder = undefined; // needed for FF
   this.isComposing = false; // keydowncode == 229  compositionevent fallback
+  this.lastInputProcessed = null; // track last processed input to prevent duplicates
   this.hasAlternator = false;
 }
 


### PR DESCRIPTION
- Add event deduplication to prevent both keyEvent and inputFallBackEvent
    from processing the same input character
  - Implements 10ms time window to catch duplicate events from Safari's
    Chinese IME which fires both input and keydown events
  - Fixes character duplication issue specific to Safari + Chinese keyboard
  - Maintains full compatibility with all other browsers and input methods

  Resolves character duplication where typing '1' would result in '11' 