### PR TITLE
Fix shiftPositions: "false" behaviour

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -1003,7 +1003,7 @@ function revalidateMask(pos, validTest, fromIsValid, validatedPos) {
     for (i = validTest ? end : end - 1; i <= lvp; i++) {
       if (
         (t = positionsClone[i]) !== undefined &&
-        t.generatedInput !== true &&
+        (opts.shiftPositions !== true || t.generatedInput !== true) &&
         (i >= end ||
           (i >= begin &&
             IsEnclosedStatic(i, positionsClone, {


### PR DESCRIPTION
Fixes following issue: #2719, as well as use-cases like this:
```
<input-mask regex="[0-9]{1,10}/[0-9]{2}/[0-9]{5}" shiftPositions="false"></input-mask>
```

I am not sure if this is the right approach, however it worked for me as a temporary fix