### PR TITLE
Fix numeric digit landing in decimal area when typed before prefix (#2615)

### DIFF
--- a/lib/extensions/inputmask.numeric.extensions.js
+++ b/lib/extensions/inputmask.numeric.extensions.js
@@ -473,6 +473,24 @@ Inputmask.extendAliases({
           return { rewritePosition: radixPos };
         }
       }
+      // Cursor placed at or before the prefix on a field with no digits
+      // would otherwise fall through to alternation switching and land
+      // in the decimal part (#2615)
+      if (
+        pos >= buffer.length - opts.prefix.length &&
+        opts.radixPoint !== "" &&
+        !isSelection &&
+        opts.__financeInput === false
+      ) {
+        const digitTest = new RegExp(opts.definitions["9"].validator);
+        if (
+          !maskset.validPositions.some(
+            vp => vp && !vp.generatedInput && digitTest.test(vp.input)
+          )
+        ) {
+          return { rewritePosition: radixPos !== -1 ? radixPos : 0 };
+        }
+      }
       return { rewritePosition: pos };
     },
     postValidation: function (

--- a/qunit/tests_numeric.js
+++ b/qunit/tests_numeric.js
@@ -2576,4 +2576,157 @@ export default function (qunit, Inputmask) {
       assert.equal(testmask.value, "-234", 'Result "' + testmask.value + '"');
     }
   );
+
+  function decimal2615Test(name, opts, actions, expected) {
+    qunit.test("decimal $ - " + name + " - #2615", function (assert) {
+      const done = assert.async(),
+        $fixture = $("#qunit-fixture");
+      $fixture.append('<input type="text" id="testmask" />');
+      const testmask = document.getElementById("testmask");
+      Inputmask("decimal", {
+        digits: 2,
+        prefix: "$",
+        ...opts
+      }).mask(testmask);
+
+      testmask.focus();
+      $("#testmask").trigger("click");
+      setTimeout(function () {
+        actions(testmask);
+        assert.equal(testmask.value, expected, "Result " + testmask.value);
+        done();
+      }, 0);
+    });
+  }
+
+  decimal2615Test(
+    "cursor at 0, type 5",
+    {},
+    function (testmask) {
+      $.caret(testmask, 0);
+      $("#testmask").SendKey("5");
+    },
+    "$5"
+  );
+
+  decimal2615Test(
+    "type -, cursor at 0, type 5",
+    {},
+    function (testmask) {
+      $("#testmask").SendKey("-");
+      $.caret(testmask, 0);
+      $("#testmask").SendKey("5");
+    },
+    "-$5"
+  );
+
+  decimal2615Test(
+    "delete all, cursor at 0, type 5",
+    {},
+    function (testmask) {
+      $("#testmask").Type("123");
+      $.caret(testmask, 0, testmask.value.length);
+      $("#testmask").SendKey(keys.Delete);
+      $.caret(testmask, 0);
+      $("#testmask").SendKey("5");
+    },
+    "$5"
+  );
+
+  decimal2615Test(
+    "digitsOptional:false, cursor at 0, type 5",
+    { digitsOptional: false },
+    function (testmask) {
+      $.caret(testmask, 0);
+      $("#testmask").SendKey("5");
+    },
+    "$5.00"
+  );
+
+  decimal2615Test(
+    "type 12345, cursor at 0, type 6 - non-regression",
+    {},
+    function (testmask) {
+      $("#testmask").Type("12345");
+      $.caret(testmask, 0);
+      $("#testmask").SendKey("6");
+    },
+    "$6123.45"
+  );
+
+  decimal2615Test(
+    "cursor at 0, type 56",
+    {},
+    function (testmask) {
+      $.caret(testmask, 0);
+      $("#testmask").SendKey("5");
+      $("#testmask").SendKey("6");
+    },
+    "$56"
+  );
+
+  decimal2615Test(
+    "radixPoint ',' groupSeparator ' ', cursor at 0, type 5",
+    { radixPoint: ",", groupSeparator: " " },
+    function (testmask) {
+      $.caret(testmask, 0);
+      $("#testmask").SendKey("5");
+    },
+    "$5"
+  );
+
+  decimal2615Test(
+    "cursor at 0, type full-width digit \uFF15",
+    {},
+    function (testmask) {
+      $.caret(testmask, 0);
+      $("#testmask").SendKey("\uFF15");
+    },
+    "$\uFF15"
+  );
+
+  // Probe tests for prefix "$ " and cursor inside prefix
+  decimal2615Test(
+    "prefix '$ ' - cursor at 0, type 5",
+    { prefix: "$ " },
+    function (testmask) {
+      $.caret(testmask, 0);
+      $("#testmask").SendKey("5");
+    },
+    "$ 5"
+  );
+
+  decimal2615Test(
+    "prefix '$ ' - cursor at 1 (middle of prefix), type 5",
+    { prefix: "$ " },
+    function (testmask) {
+      $.caret(testmask, 1);
+      $("#testmask").SendKey("5");
+    },
+    "$ 5"
+  );
+
+  decimal2615Test(
+    "type 12345, cursor at 0, type 67",
+    {},
+    function (testmask) {
+      $("#testmask").Type("12345");
+      $.caret(testmask, 0);
+      $("#testmask").SendKey("6");
+      $("#testmask").SendKey("7");
+    },
+    "$67123.45"
+  );
+
+  decimal2615Test(
+    "prefix '$ ' - type 12345, cursor at 0, type 67",
+    { prefix: "$ " },
+    function (testmask) {
+      $("#testmask").Type("12345");
+      $.caret(testmask, 0);
+      $("#testmask").SendKey("6");
+      $("#testmask").SendKey("7");
+    },
+    "$ 67123.45"
+  );
 }


### PR DESCRIPTION
﻿## Summary

When the cursor is placed before the prefix on a numeric mask with `radixPoint`, the DOM position translates past the buffer end, causing `_isValid` to fall through to alternation switching and place the digit in the decimal area (e.g. typing "5" produced "$0.5" instead of "$5").

- Detect this case in `preValidation` and redirect to the integer part when the field has no entered digits
- The check ignores positions populated by `checkVal` (`generatedInput`) and the negation symbol, so the fix also applies after typing "-" alone

Closes #2615, closes #1367

## Test plan

- Added 12 QUnit tests covering:
  - cursor at position 0 with empty field
  - cursor at 0 after typing `-`
  - cursor at 0 after deleting all content
  - `digitsOptional: false` variant
  - non-regression: cursor at 0 when digits already present
  - multi-digit typing at position 0
  - alternative `radixPoint`/`groupSeparator`
  - full-width digit input
  - multi-character prefix (`"$ "`) with cursor at 0 and mid-prefix
  - multi-digit non-regression with existing value

## AI disclosure

This PR was written primarily by Claude Code. Follow-up fixes were reviewed and amended by Codex.

