### PR TITLE
fix year edit clearing every segment behind the year #2610

### DIFF
--- a/lib/extensions/date.js
+++ b/lib/extensions/date.js
@@ -961,6 +961,10 @@ const datetimeAlias = {
         maskset.validPositions[tokenMatch.targetMatchIndex + 1].input = "0";
       }
       if (fcode[2] == "year") {
+        // Clear the rest of the year while it is being retyped, so a half typed year does not
+        // keep validating against the previous digits. Bounded to the year token: running to
+        // buffer.length wiped every segment behind it, and splicing shifted those positions
+        // down instead of clearing them.
         const _buffer = getMaskTemplate.call(
           inputmask,
           false,
@@ -968,9 +972,11 @@ const datetimeAlias = {
           undefined,
           true
         );
-        for (let i = pos + 1; i < buffer.length; i++) {
+        const yearEnd =
+          tokenMatch.targetMatchIndex + tokenMatch.targetMatch[0].length;
+        for (let i = pos + 1; i < yearEnd; i++) {
           buffer[i] = _buffer[i];
-          maskset.validPositions.splice(pos + 1, 1);
+          delete maskset.validPositions[i];
         }
       }
     }

--- a/qunit/tests_date.js
+++ b/qunit/tests_date.js
@@ -1542,4 +1542,141 @@ export default function (qunit, Inputmask) {
       "Result " + testmask.value
     );
   });
+
+  // Typing into one segment must leave the other segments alone. That holds for every segment
+  // except the year: date.js rewrites all positions after the year from the mask template on
+  // every keystroke, so everything behind the year is wiped. See mcve/year-edit-clears-time/
+  // for a runnable demonstration and for the exact block responsible.
+  qunit.test(
+    "dd.MM.yyyy HH:mm - typing in the year keeps the time",
+    function (assert) {
+      var $fixture = $("#qunit-fixture");
+      $fixture.append('<input type="text" id="testmask" />');
+      var testmask = document.getElementById("testmask");
+      Inputmask("datetime", {
+        inputFormat: "dd.MM.yyyy HH:mm"
+      }).mask(testmask);
+
+      testmask.focus();
+      $("#testmask").Type("030820261430");
+      $.caret(testmask, 6);
+      $("#testmask").Type("1");
+
+      assert.equal(
+        testmask.value,
+        "03.08.1yyy 14:30",
+        "Result " + testmask.value
+      );
+    }
+  );
+
+  // Same defect with the year in front: month and day are lost instead of the time.
+  qunit.test(
+    "yyyy-MM-dd - typing in the year keeps month and day",
+    function (assert) {
+      var $fixture = $("#qunit-fixture");
+      $fixture.append('<input type="text" id="testmask" />');
+      var testmask = document.getElementById("testmask");
+      Inputmask("datetime", {
+        inputFormat: "yyyy-MM-dd"
+      }).mask(testmask);
+
+      testmask.focus();
+      $("#testmask").Type("20260803");
+      $.caret(testmask, 0);
+      $("#testmask").Type("1");
+
+      assert.equal(testmask.value, "1yyy-08-03", "Result " + testmask.value);
+    }
+  );
+
+  // Not about the width of the token: a two-digit year loses the time just the same.
+  qunit.test(
+    "dd.MM.yy HH:mm - typing in the two digit year keeps the time",
+    function (assert) {
+      var $fixture = $("#qunit-fixture");
+      $fixture.append('<input type="text" id="testmask" />');
+      var testmask = document.getElementById("testmask");
+      Inputmask("datetime", {
+        inputFormat: "dd.MM.yy HH:mm"
+      }).mask(testmask);
+
+      testmask.focus();
+      $("#testmask").Type("0308261430");
+      $.caret(testmask, 6);
+      $("#testmask").Type("9");
+
+      assert.equal(testmask.value, "03.08.9y 14:30", "Result " + testmask.value);
+    }
+  );
+
+  qunit.test(
+    "dd.MM.yyyy HH:mm - retyping the year keeps the time",
+    function (assert) {
+      var $fixture = $("#qunit-fixture");
+      $fixture.append('<input type="text" id="testmask" />');
+      var testmask = document.getElementById("testmask");
+      Inputmask("datetime", {
+        inputFormat: "dd.MM.yyyy HH:mm"
+      }).mask(testmask);
+
+      testmask.focus();
+      $("#testmask").Type("030820261430");
+      $.caret(testmask, 6, 10);
+      $("#testmask").Type("1");
+
+      assert.equal(
+        testmask.value,
+        "03.08.1yyy 14:30",
+        "Result " + testmask.value
+      );
+    }
+  );
+
+  qunit.test(
+    "dd.MM.yyyy HH:mm - retyping the whole year keeps the time",
+    function (assert) {
+      var $fixture = $("#qunit-fixture");
+      $fixture.append('<input type="text" id="testmask" />');
+      var testmask = document.getElementById("testmask");
+      Inputmask("datetime", {
+        inputFormat: "dd.MM.yyyy HH:mm"
+      }).mask(testmask);
+
+      testmask.focus();
+      $("#testmask").Type("030820261430");
+      $.caret(testmask, 6, 10);
+      $("#testmask").Type("1999");
+
+      assert.equal(
+        testmask.value,
+        "03.08.1999 14:30",
+        "Result " + testmask.value
+      );
+    }
+  );
+
+  // Counter-check: the same edit on the month leaves the time alone.
+  qunit.test(
+    "dd.MM.yyyy HH:mm - retyping the month keeps the time",
+    function (assert) {
+      var $fixture = $("#qunit-fixture");
+      $fixture.append('<input type="text" id="testmask" />');
+      var testmask = document.getElementById("testmask");
+      Inputmask("datetime", {
+        inputFormat: "dd.MM.yyyy HH:mm"
+      }).mask(testmask);
+
+      testmask.focus();
+      $("#testmask").Type("030820261430");
+      $.caret(testmask, 3, 5);
+      $("#testmask").Type("1");
+
+      assert.equal(
+        testmask.value,
+        "03.1M.2026 14:30",
+        "Result " + testmask.value
+      );
+    }
+  );
 }


### PR DESCRIPTION
Fixes #2610.

Put the caret in the year of a filled field and type one digit. Everything after the year is
replaced by the mask template:

```
inputFormat "dd.MM.yyyy HH:mm"
value              03.08.2026 14:30
caret at 6, type 1
value              03.08.1yyy HH:mm    (expected 03.08.1yyy 14:30)
```

With the year in front, month and day go instead: `yyyy-MM-dd`, `2026-08-03`, caret at 0, type `1`
gives `1yyy-MM-dd`. A two-digit year behaves the same, so it is the year token and not its width.
Other segments are fine, retyping the month keeps the time.

Reproduction: https://codepen.io/duschata/pen/EaZJmXK (runs 5.1.0-beta.17)

Affects 5.0.7 through 5.1.0-beta.17. 5.0.6 is fine, as the "v5.0.6 works" comment in #2610 says: the
block came in with 240dcd25, which is in tag 5.0.7 but not in 5.0.6. Same results in Chromium and
Firefox.

Cause: in `postValidation`, the block guarded by `fcode[2] == "year"` loops to `buffer.length`
instead of the end of the year token, and `splice(pos + 1, 1)` shifts the positions behind the year
down instead of clearing them. Clearing the rest of the year is clearly intended, without the block
you get `03.08.1026` instead of `03.08.1yyy`. The loop just doesn't stop at the token boundary.

The fix bounds the loop to the year token and drops the positions in place. Both parts are needed:
bounding it while keeping the splice leaves `03.08.19:30` in the field.

First commit adds six tests to `qunit/tests_date.js`, second commit is the fix. 602 SUCCESS /
5 FAILED before, 607 SUCCESS after. I ran karma directly against ChromeHeadless because `npm test`
wants BrowserStack credentials, and `npm install` needed `--legacy-peer-deps` — both pre-existing
on 5.x.