### PR TITLE
Ignore keydown events that have no key info instead of crashing

### DIFF
--- a/lib/eventhandlers.js
+++ b/lib/eventhandlers.js
@@ -33,8 +33,15 @@ const EventHandlers = {
       maskset = inputmask.maskset,
       input = this,
       $input = $(input),
-      c = e.key,
-      pos = caret.call(inputmask, input),
+      c = e.key;
+
+    // Browsers and password managers can fill in a field in a way that fires
+    // a keydown event without any real key attached to it (it isn't an
+    // actual keystroke). If we don't stop here, the code below assumes a
+    // real key was pressed and crashes the page.
+    if (!c) return;
+
+    const pos = caret.call(inputmask, input),
       kdResult = opts.onKeyDown.call(
         this,
         e,

--- a/qunit/tests_base.js
+++ b/qunit/tests_base.js
@@ -648,4 +648,27 @@ export default function (qunit, Inputmask) {
       }, 0);
     }
   );
+
+  qunit.test(
+    "keydown event with no key (e.g. browser autofill) should not throw",
+    function (assert) {
+      const $fixture = $("#qunit-fixture");
+      $fixture.append('<input type="text" id="testmask" />');
+      const testmask = document.getElementById("testmask");
+      Inputmask("999.999.999").mask(testmask);
+
+      testmask.focus();
+
+      let threw = false;
+      try {
+        // a bare autofill/password-manager keydown has no `key` (or any
+        // other KeyboardEvent property) set on it
+        testmask.dispatchEvent(new Event("keydown"));
+      } catch (e) {
+        threw = true;
+      }
+
+      assert.notOk(threw, "keydown without a key should not throw");
+    }
+  );
 }


### PR DESCRIPTION
Inputmask always assumed a keydown event came from a real keystroke, so it looked at which key was pressed without checking whether that information was even there. Browsers and password managers can autofill a field in a way that fires a keydown event with no key info attached (it isn't an actual keystroke), and that used to crash the page. Now that case is simply ignored, so autofill no longer breaks anything and typing still works exactly as before.