### PR TITLE
fix: fix security issue in MarkDownPage.js

### DIFF
--- a/inputmask-pages/src/Components/MarkDownPage/MarkDownPage.js
+++ b/inputmask-pages/src/Components/MarkDownPage/MarkDownPage.js
@@ -7,10 +7,37 @@ import remarkGfm from "remark-gfm";
 import remarkParse from "remark-parse";
 import remarkRehype from "remark-rehype";
 import { unified } from "unified";
+import { visit } from "unist-util-visit";
 
 import styles from "./MarkDownPage.module.scss";
 import "highlight.js/scss/github-dark-dimmed.scss";
 import { MarkDownPageContext } from "./MarkDownPageContext";
+
+const DANGEROUS_TAGS = new Set(["script", "iframe", "object", "embed", "style"]);
+const UNSAFE_URL = /^\s*(javascript|data|vbscript):/i;
+
+// Strips executable content (script/iframe tags, on*-handlers and
+// javascript:/data: URLs) from the fetched markdown's HTML tree before it
+// is turned into React elements, since the markdown is fetched from a
+// caller-supplied, potentially untrusted `md` URL.
+const sanitizeHast = () => (tree) => {
+  visit(tree, "element", (node) => {
+    if (DANGEROUS_TAGS.has(node.tagName)) {
+      node.tagName = "span";
+      node.children = [];
+      node.properties = {};
+      return;
+    }
+    if (node.properties) {
+      Object.keys(node.properties).forEach((key) => {
+        const value = node.properties[key];
+        if (/^on/i.test(key) || ((key === "href" || key === "src") && typeof value === "string" && UNSAFE_URL.test(value))) {
+          delete node.properties[key];
+        }
+      });
+    }
+  });
+};
 
 export const MarkDownPage = (props) => {
   const { className, md, children } = props,
@@ -27,6 +54,7 @@ export const MarkDownPage = (props) => {
           .use(rehypeSlug)
           .use(rehypeAutolinkHeadings)
           .use(rehypeHighlight, { detect: true })
+          .use(sanitizeHast)
           .use(rehypeReact, { createElement, Fragment })
           .process(text.replace(/{{year}}/g, new Date().getFullYear()))
           .then((file) => {


### PR DESCRIPTION
## Summary
Fix high severity security issue in `inputmask-pages/src/Components/MarkDownPage/MarkDownPage.js`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `inputmask-pages/src/Components/MarkDownPage/MarkDownPage.js:10` |
| **Assessment** | Likely exploitable |

**Description**: The MarkDownPage component fetches markdown content from an external URL passed via the `md` prop and renders it through the unified/remark/rehype pipeline without sanitization. The pipeline converts markdown to React components directly via rehypeReact, allowing arbitrary HTML and JavaScript execution if the fetched markdown contains malicious content. No DOMPurify or similar sanitization library is present in the processing pipeline.

## Evidence

**Exploitation scenario**: An attacker who controls or compromises the external markdown file URL can inject malicious JavaScript.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `inputmask-pages/src/Components/MarkDownPage/MarkDownPage.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=V-001 scanner=multi_agent_ai -->
